### PR TITLE
ticket_699

### DIFF
--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10 SiSyPHuS HD-BSI-1.3#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10 SiSyPHuS HD-BSI-1.3#RegistrySettings.ps1
@@ -6636,7 +6636,7 @@ $windefrunning = CheckWindefRunning
 }
 [AuditTest] @{
     Id   = "172 A"
-    Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Set the state for each ASR rule' is configured (Block Office communication application  from creating child processes)"
+    Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Set the state for each ASR rule' is configured (Block Office communication application from creating child processes)"
     Test = {
         try {
             if ($avstatus) {

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-Stand-alone-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-Stand-alone-CIS-2.0.0#RegistrySettings.ps1
@@ -5,1028 +5,1028 @@ $avstatus = CheckForActiveAV
 $windefrunning = CheckWindefRunning
 . "$RootPath\Helpers\Firewall.ps1"
 [AuditTest] @{
-    Id = "1.1.6"
+    Id   = "1.1.6"
     Task = "(L1) Ensure 'Relax minimum password length limits' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SAM" `
                 -Name "RelaxMinimumPasswordLengthLimits" `
-                | Select-Object -ExpandProperty "RelaxMinimumPasswordLengthLimits"
+            | Select-Object -ExpandProperty "RelaxMinimumPasswordLengthLimits"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.1.1"
+    Id   = "2.3.1.1"
     Task = "(L1) Ensure 'Accounts: Block Microsoft accounts' is set to 'Users can't add or log on with Microsoft accounts'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "NoConnectedUser" `
-                | Select-Object -ExpandProperty "NoConnectedUser"
+            | Select-Object -ExpandProperty "NoConnectedUser"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.1.3"
+    Id   = "2.3.1.3"
     Task = "(L1) Ensure 'Accounts: Limit local account use of blank passwords to console logon only' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "LimitBlankPasswordUse" `
-                | Select-Object -ExpandProperty "LimitBlankPasswordUse"
+            | Select-Object -ExpandProperty "LimitBlankPasswordUse"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.2.1"
+    Id   = "2.3.2.1"
     Task = "(L1) Ensure 'Audit: Force audit policy subcategory settings (Windows Vista or later) to override audit policy category settings' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "SCENoApplyLegacyAuditPolicy" `
-                | Select-Object -ExpandProperty "SCENoApplyLegacyAuditPolicy"
+            | Select-Object -ExpandProperty "SCENoApplyLegacyAuditPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.2.2"
+    Id   = "2.3.2.2"
     Task = "(L1) Ensure 'Audit: Shut down system immediately if unable to log security audits' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "CrashOnAuditFail" `
-                | Select-Object -ExpandProperty "CrashOnAuditFail"
+            | Select-Object -ExpandProperty "CrashOnAuditFail"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.4.1"
+    Id   = "2.3.4.1"
     Task = "(L2) Ensure 'Devices: Prevent users from installing printer drivers' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print\Providers\LanMan Print Services\Servers" `
                 -Name "AddPrinterDrivers" `
-                | Select-Object -ExpandProperty "AddPrinterDrivers"
+            | Select-Object -ExpandProperty "AddPrinterDrivers"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.1"
+    Id   = "2.3.7.1"
     Task = "(L1) Ensure 'Interactive logon: Do not require CTRL+ALT+DEL' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "DisableCAD" `
-                | Select-Object -ExpandProperty "DisableCAD"
+            | Select-Object -ExpandProperty "DisableCAD"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.2"
+    Id   = "2.3.7.2"
     Task = "(L1) Ensure 'Interactive logon: Don't display last signed-in' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "DontDisplayLastUserName" `
-                | Select-Object -ExpandProperty "DontDisplayLastUserName"
+            | Select-Object -ExpandProperty "DontDisplayLastUserName"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.3"
+    Id   = "2.3.7.3"
     Task = "(BL) Ensure 'Interactive logon: Machine account lockout threshold' is set to '10 or fewer invalid logon attempts, but not 0'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "MaxDevicePasswordFailedAttempts" `
-                | Select-Object -ExpandProperty "MaxDevicePasswordFailedAttempts"
+            | Select-Object -ExpandProperty "MaxDevicePasswordFailedAttempts"
         
             if (($regValue -gt 10 -or $regValue -le 3)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x <= 10 and x > 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.4"
+    Id   = "2.3.7.4"
     Task = "(L1) Ensure 'Interactive logon: Machine inactivity limit' is set to '900 or fewer second(s), but not 0'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "InactivityTimeoutSecs" `
-                | Select-Object -ExpandProperty "InactivityTimeoutSecs"
+            | Select-Object -ExpandProperty "InactivityTimeoutSecs"
         
             if (($regValue -gt 900 -or $regValue -eq 0)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x <= 900 and x != 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.5"
+    Id   = "2.3.7.5"
     Task = "(L1) Configure 'Interactive logon: Message text for users attempting to log on'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "LegalNoticeText" `
-                | Select-Object -ExpandProperty "LegalNoticeText"
+            | Select-Object -ExpandProperty "LegalNoticeText"
         
             $regValue = $regValue.Trim([char]0x0000)    
             if (($regValue -notmatch ".+") -or ([string]::IsNullOrEmpty($regValue)) -or ([string]::IsNullOrWhiteSpace($regValue))) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: Matching expression '.+'"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.6"
+    Id   = "2.3.7.6"
     Task = "(L1) Configure 'Interactive logon: Message title for users attempting to log on'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "LegalNoticeCaption" `
-                | Select-Object -ExpandProperty "LegalNoticeCaption"
+            | Select-Object -ExpandProperty "LegalNoticeCaption"
         
             $regValue = $regValue.Trim([char]0x0000)    
             if (($regValue -notmatch ".+") -or ([string]::IsNullOrEmpty($regValue)) -or ([string]::IsNullOrWhiteSpace($regValue))) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: Matching expression '.+'"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.7"
+    Id   = "2.3.7.7"
     Task = "(L1) Ensure 'Interactive logon: Prompt user to change password before expiration' is set to 'between 5 and 14 days'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" `
                 -Name "PasswordExpiryWarning" `
-                | Select-Object -ExpandProperty "PasswordExpiryWarning"
+            | Select-Object -ExpandProperty "PasswordExpiryWarning"
         
             if (($regValue -lt 5 -or $regValue -gt 14)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 5 and x <= 14"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.7.8"
+    Id   = "2.3.7.8"
     Task = "(L1) Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" `
                 -Name "ScRemoveOption" `
-                | Select-Object -ExpandProperty "ScRemoveOption"
+            | Select-Object -ExpandProperty "ScRemoveOption"
         
             if ($regValue -notmatch "^(1|2|3)$") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: Matching expression '^(1|2|3)$'"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.8.1"
+    Id   = "2.3.8.1"
     Task = "(L1) Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'"
     Test = {
         try {
-            if((Get-SmbClientConfiguration).RequireSecuritySignature -ne $True){
+            if ((Get-SmbClientConfiguration).RequireSecuritySignature -ne $True) {
                 return @{
                     Message = "RequireSecuritySignature is not set to True"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             return @{
                 Message = "Compliant"
-                Status = "True"
+                Status  = "True"
             }
         }
         catch {
-            try{
+            try {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
-                -Name "RequireSecuritySignature" `
+                    -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
+                    -Name "RequireSecuritySignature" `
                 | Select-Object -ExpandProperty "RequireSecuritySignature"
                 
                 if ($regValue -ne 1) {
                     return @{
                         Message = "Registry value is '$regValue'. Expected: 1"
-                        Status = "False"
+                        Status  = "False"
                     }
                 }
                 return @{
                     Message = "Compliant"
-                    Status = "True"
+                    Status  = "True"
                 }
             }
             catch [System.Management.Automation.PSArgumentException] {
                 return @{
                     Message = "Registry value not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             catch [System.Management.Automation.ItemNotFoundException] {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.8.2"
+    Id   = "2.3.8.2"
     Task = "(L1) Ensure 'Microsoft network client: Digitally sign communications (if server agrees)' is set to 'Enabled'"
     Test = {
         try {
-            if((Get-SmbClientConfiguration).EnableSecuritySignature -ne $True){
+            if ((Get-SmbClientConfiguration).EnableSecuritySignature -ne $True) {
                 return @{
                     Message = "EnableSecuritySignature is not set to True"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             return @{
                 Message = "Compliant"
-                Status = "True"
+                Status  = "True"
             }
         }
         catch {
-            try{
+            try {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
-                -Name "EnableSecuritySignature" `
+                    -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
+                    -Name "EnableSecuritySignature" `
                 | Select-Object -ExpandProperty "EnableSecuritySignature"
                 
                 if ($regValue -ne 1) {
                     return @{
                         Message = "Registry value is '$regValue'. Expected: 1"
-                        Status = "False"
+                        Status  = "False"
                     }
                 }
                 return @{
                     Message = "Compliant"
-                    Status = "True"
+                    Status  = "True"
                 }
             }
             catch [System.Management.Automation.PSArgumentException] {
                 return @{
                     Message = "Registry value not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             catch [System.Management.Automation.ItemNotFoundException] {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.8.3"
+    Id   = "2.3.8.3"
     Task = "(L1) Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
                 -Name "EnablePlainTextPassword" `
-                | Select-Object -ExpandProperty "EnablePlainTextPassword"
+            | Select-Object -ExpandProperty "EnablePlainTextPassword"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.9.1"
+    Id   = "2.3.9.1"
     Task = "(L1) Ensure 'Microsoft network server: Amount of idle time required before suspending session' is set to '15 or fewer minute(s)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "AutoDisconnect" `
-                | Select-Object -ExpandProperty "AutoDisconnect"
+            | Select-Object -ExpandProperty "AutoDisconnect"
         
             if (($regValue -gt 15)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x <= 15"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.9.2"
+    Id   = "2.3.9.2"
     Task = "(L1) Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'"
     Test = {
         try {
-            if((Get-SmbServerConfiguration -ErrorAction Stop).RequireSecuritySignature -ne $True){
+            if ((Get-SmbServerConfiguration -ErrorAction Stop).RequireSecuritySignature -ne $True) {
                 return @{
                     Message = "RequireSecuritySignature is not set to True"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             return @{
                 Message = "Compliant"
-                Status = "True"
+                Status  = "True"
             }
         }
         catch {
-                       try{
+            try {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
-                -Name "RequireSecuritySignature" `
+                    -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
+                    -Name "RequireSecuritySignature" `
                 | Select-Object -ExpandProperty "RequireSecuritySignature"
                 
                 return @{
                     Message = "Registry value is '$regValue'. Get-SMBServerConfiguration failed, resorted to checking registry, which might not be 100% accurate. See <a href=`"https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/overview-server-message-block-signing#policy-locations-for-smb-signing`">here</a> and <a href=`"https://techcommunity.microsoft.com/t5/storage-at-microsoft/smb-signing-required-by-default-in-windows-insider/ba-p/3831704`">here</a>"
-                    Status = "Warning"
+                    Status  = "Warning"
                 }
             }
             catch [System.Management.Automation.PSArgumentException] {
                 return @{
                     Message = "Registry value not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             catch [System.Management.Automation.ItemNotFoundException] {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.9.3"
+    Id   = "2.3.9.3"
     Task = "(L1) Ensure 'Microsoft network server: Digitally sign communications (if client agrees)' is set to 'Enabled'"
     Test = {
         try {
-            if((Get-SmbServerConfiguration -ErrorAction Stop).EnableSecuritySignature -ne $True){
+            if ((Get-SmbServerConfiguration -ErrorAction Stop).EnableSecuritySignature -ne $True) {
                 return @{
                     Message = "EnableSecuritySignature is not set to True"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             return @{
                 Message = "Compliant"
-                Status = "True"
+                Status  = "True"
             }
         }
         catch {
-            try{
+            try {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
-                -Name "EnableSecuritySignature" `
+                    -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
+                    -Name "EnableSecuritySignature" `
                 | Select-Object -ExpandProperty "EnableSecuritySignature"
                 
                 return @{
                     Message = "Registry value is '$regValue'. Get-SMBServerConfiguration failed, resorted to checking registry, which might not be 100% accurate. See <a href=`"https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/overview-server-message-block-signing#policy-locations-for-smb-signing`">here</a> and <a href=`"https://techcommunity.microsoft.com/t5/storage-at-microsoft/smb-signing-required-by-default-in-windows-insider/ba-p/3831704`">here</a>"
-                    Status = "Warning"
+                    Status  = "Warning"
                 }
             }
             catch [System.Management.Automation.PSArgumentException] {
                 return @{
                     Message = "Registry value not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             catch [System.Management.Automation.ItemNotFoundException] {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.9.4"
+    Id   = "2.3.9.4"
     Task = "(L1) Ensure 'Microsoft network server: Disconnect clients when logon hours expire' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "enableforcedlogoff" `
-                | Select-Object -ExpandProperty "enableforcedlogoff"
+            | Select-Object -ExpandProperty "enableforcedlogoff"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.9.5"
+    Id   = "2.3.9.5"
     Task = "(L1) Ensure 'Microsoft network server: Server SPN target name validation level' is set to 'Accept if provided by client' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "SMBServerNameHardeningLevel" `
-                | Select-Object -ExpandProperty "SMBServerNameHardeningLevel"
+            | Select-Object -ExpandProperty "SMBServerNameHardeningLevel"
         
             if (($regValue -lt 1)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.2"
+    Id   = "2.3.10.2"
     Task = "(L1) Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "RestrictAnonymousSAM" `
-                | Select-Object -ExpandProperty "RestrictAnonymousSAM"
+            | Select-Object -ExpandProperty "RestrictAnonymousSAM"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.3"
+    Id   = "2.3.10.3"
     Task = "(L1) Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts and shares' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "RestrictAnonymous" `
-                | Select-Object -ExpandProperty "RestrictAnonymous"
+            | Select-Object -ExpandProperty "RestrictAnonymous"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.4"
+    Id   = "2.3.10.4"
     Task = "(L1) Ensure 'Network access: Do not allow storage of passwords and credentials for network authentication' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "DisableDomainCreds" `
-                | Select-Object -ExpandProperty "DisableDomainCreds"
+            | Select-Object -ExpandProperty "DisableDomainCreds"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.5"
+    Id   = "2.3.10.5"
     Task = "(L1) Ensure 'Network access: Let Everyone permissions apply to anonymous users' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "EveryoneIncludesAnonymous" `
-                | Select-Object -ExpandProperty "EveryoneIncludesAnonymous"
+            | Select-Object -ExpandProperty "EveryoneIncludesAnonymous"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.6"
+    Id   = "2.3.10.6"
     Task = "(L1) Ensure 'Network access: Named Pipes that can be accessed anonymously' is set to 'None'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "NullSessionPipes" `
-                | Select-Object -ExpandProperty "NullSessionPipes"
+            | Select-Object -ExpandProperty "NullSessionPipes"
         
             if ($regValue -ne "") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: "
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.7"
+    Id   = "2.3.10.7"
     Task = "(L1) Ensure 'Network access: Remotely accessible registry paths' is configured"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedExactPaths" `
                 -Name "Machine" `
-                | Select-Object -ExpandProperty "Machine"
+            | Select-Object -ExpandProperty "Machine"
         
             $reference = @(
                 "System\CurrentControlSet\Control\ProductOptions"
@@ -1036,38 +1036,38 @@ $windefrunning = CheckWindefRunning
             if (-not (Test-ArrayEqual $regValue $reference)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: System\CurrentControlSet\Control\ProductOptions System\CurrentControlSet\Control\Server Applications Software\Microsoft\Windows NT\CurrentVersion"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.8"
+    Id   = "2.3.10.8"
     Task = "(L1) Configure 'Network access: Remotely accessible registry paths and sub-paths'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\Winreg\AllowedPaths" `
                 -Name "Machine" `
-                | Select-Object -ExpandProperty "Machine"
+            | Select-Object -ExpandProperty "Machine"
         
             $reference = @(
                 "System\CurrentControlSet\Control\Print\Printers"
@@ -1085,2587 +1085,2587 @@ $windefrunning = CheckWindefRunning
             if (-not (Test-ArrayEqual $regValue $reference)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: System\CurrentControlSet\Control\Print\Printers System\CurrentControlSet\Services\Eventlog Software\Microsoft\OLAP Server Software\Microsoft\Windows NT\CurrentVersion\Print Software\Microsoft\Windows NT\CurrentVersion\Windows System\CurrentControlSet\Control\ContentIndex System\CurrentControlSet\Control\Terminal Server System\CurrentControlSet\Control\Terminal Server\UserConfig System\CurrentControlSet\Control\Terminal Server\DefaultUserConfiguration Software\Microsoft\Windows NT\CurrentVersion\Perflib System\CurrentControlSet\Services\SysmonLog"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.9"
+    Id   = "2.3.10.9"
     Task = "(L1) Ensure 'Network access: Restrict anonymous access to Named Pipes and Shares' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "RestrictNullSessAccess" `
-                | Select-Object -ExpandProperty "RestrictNullSessAccess"
+            | Select-Object -ExpandProperty "RestrictNullSessAccess"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.10"
+    Id   = "2.3.10.10"
     Task = "(L1) Ensure 'Network access: Restrict clients allowed to make remote calls to SAM' is set to 'Administrators: Remote Access: Allow'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "restrictremotesam" `
-                | Select-Object -ExpandProperty "restrictremotesam"
+            | Select-Object -ExpandProperty "restrictremotesam"
         
             if ($regValue -ne "O:BAG:BAD:(A;;RC;;;BA)") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: O:BAG:BAD:(A;;RC;;;BA)"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.11"
+    Id   = "2.3.10.11"
     Task = "(L1) Ensure 'Network access: Shares that can be accessed anonymously' is set to 'None'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "NullSessionShares" `
-                | Select-Object -ExpandProperty "NullSessionShares"
+            | Select-Object -ExpandProperty "NullSessionShares"
         
             if ($regValue -ne "") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: "
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.10.12"
+    Id   = "2.3.10.12"
     Task = "(L1) Ensure 'Network access: Sharing and security model for local accounts' is set to 'Classic - local users authenticate as themselves'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "ForceGuest" `
-                | Select-Object -ExpandProperty "ForceGuest"
+            | Select-Object -ExpandProperty "ForceGuest"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.1"
+    Id   = "2.3.11.1"
     Task = "(L1) Ensure 'Network security: Allow Local System to use computer identity for NTLM' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "UseMachineId" `
-                | Select-Object -ExpandProperty "UseMachineId"
+            | Select-Object -ExpandProperty "UseMachineId"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.2"
+    Id   = "2.3.11.2"
     Task = "(L1) Ensure 'Network security: Allow LocalSystem NULL session fallback' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0" `
                 -Name "AllowNullSessionFallback" `
-                | Select-Object -ExpandProperty "AllowNullSessionFallback"
+            | Select-Object -ExpandProperty "AllowNullSessionFallback"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.3"
+    Id   = "2.3.11.3"
     Task = "(L1) Ensure 'Network Security: Allow PKU2U authentication requests to this computer to use online identities' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\pku2u" `
                 -Name "AllowOnlineID" `
-                | Select-Object -ExpandProperty "AllowOnlineID"
+            | Select-Object -ExpandProperty "AllowOnlineID"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.4"
+    Id   = "2.3.11.4"
     Task = "(L1) Ensure 'Network security: Configure encryption types allowed for Kerberos' is set to 'AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\Kerberos\Parameters" `
                 -Name "SupportedEncryptionTypes" `
-                | Select-Object -ExpandProperty "SupportedEncryptionTypes"
+            | Select-Object -ExpandProperty "SupportedEncryptionTypes"
         
             if ($regValue -ne 2147483640) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2147483640"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.5"
+    Id   = "2.3.11.5"
     Task = "(L1) Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "NoLMHash" `
-                | Select-Object -ExpandProperty "NoLMHash"
+            | Select-Object -ExpandProperty "NoLMHash"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.7"
+    Id   = "2.3.11.7"
     Task = "(L1) Ensure 'Network security: LAN Manager authentication level' is set to 'Send NTLMv2 response only. Refuse LM&NTLM'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "LmCompatibilityLevel" `
-                | Select-Object -ExpandProperty "LmCompatibilityLevel"
+            | Select-Object -ExpandProperty "LmCompatibilityLevel"
         
             if ($regValue -ne 5) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 5"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.8"
+    Id   = "2.3.11.8"
     Task = "(L1) Ensure 'Network security: LDAP client signing requirements' is set to 'Negotiate signing' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LDAP" `
                 -Name "LDAPClientIntegrity" `
-                | Select-Object -ExpandProperty "LDAPClientIntegrity"
+            | Select-Object -ExpandProperty "LDAPClientIntegrity"
         
             if (($regValue -lt 1)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.9"
+    Id   = "2.3.11.9"
     Task = "(L1) Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) clients' is set to 'Require NTLMv2 session security, Require 128-bit encryption'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0" `
                 -Name "NTLMMinClientSec" `
-                | Select-Object -ExpandProperty "NTLMMinClientSec"
+            | Select-Object -ExpandProperty "NTLMMinClientSec"
         
             if ($regValue -ne 537395200) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 537395200"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.11.10"
+    Id   = "2.3.11.10"
     Task = "(L1) Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) servers' is set to 'Require NTLMv2 session security, Require 128-bit encryption'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0" `
                 -Name "NTLMMinServerSec" `
-                | Select-Object -ExpandProperty "NTLMMinServerSec"
+            | Select-Object -ExpandProperty "NTLMMinServerSec"
         
             if ($regValue -ne 537395200) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 537395200"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.14.1"
+    Id   = "2.3.14.1"
     Task = "(L2) Ensure 'System cryptography: Force strong key protection for user keys stored on the computer' is set to 'User is prompted when the key is first used' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Cryptography" `
                 -Name "ForceKeyProtection" `
-                | Select-Object -ExpandProperty "ForceKeyProtection"
+            | Select-Object -ExpandProperty "ForceKeyProtection"
         
             if (($regValue -ne 1) -and ($regValue -ne 2)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1 or 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.15.1"
+    Id   = "2.3.15.1"
     Task = "(L1) Ensure 'System objects: Require case insensitivity for non-Windows subsystems' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Kernel" `
                 -Name "ObCaseInsensitive" `
-                | Select-Object -ExpandProperty "ObCaseInsensitive"
+            | Select-Object -ExpandProperty "ObCaseInsensitive"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.15.2"
+    Id   = "2.3.15.2"
     Task = "(L1) Ensure 'System objects: Strengthen default permissions of internal system objects (e.g. Symbolic Links)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager" `
                 -Name "ProtectionMode" `
-                | Select-Object -ExpandProperty "ProtectionMode"
+            | Select-Object -ExpandProperty "ProtectionMode"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.1"
+    Id   = "2.3.17.1"
     Task = "(L1) Ensure 'User Account Control: Admin Approval Mode for the Built-in Administrator account' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "FilterAdministratorToken" `
-                | Select-Object -ExpandProperty "FilterAdministratorToken"
+            | Select-Object -ExpandProperty "FilterAdministratorToken"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.2"
+    Id   = "2.3.17.2"
     Task = "(L1) Ensure 'User Account Control: Behavior of the elevation prompt for administrators in Admin Approval Mode' is set to 'Prompt for consent on the secure desktop' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "ConsentPromptBehaviorAdmin" `
-                | Select-Object -ExpandProperty "ConsentPromptBehaviorAdmin"
+            | Select-Object -ExpandProperty "ConsentPromptBehaviorAdmin"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.3"
+    Id   = "2.3.17.3"
     Task = "(L1) Ensure 'User Account Control: Behavior of the elevation prompt for standard users' is set to 'Automatically deny elevation requests'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "ConsentPromptBehaviorUser" `
-                | Select-Object -ExpandProperty "ConsentPromptBehaviorUser"
+            | Select-Object -ExpandProperty "ConsentPromptBehaviorUser"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.4"
+    Id   = "2.3.17.4"
     Task = "(L1) Ensure 'User Account Control: Detect application installations and prompt for elevation' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableInstallerDetection" `
-                | Select-Object -ExpandProperty "EnableInstallerDetection"
+            | Select-Object -ExpandProperty "EnableInstallerDetection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.5"
+    Id   = "2.3.17.5"
     Task = "(L1) Ensure 'User Account Control: Only elevate UIAccess applications that are installed in secure locations' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableSecureUIAPaths" `
-                | Select-Object -ExpandProperty "EnableSecureUIAPaths"
+            | Select-Object -ExpandProperty "EnableSecureUIAPaths"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.6"
+    Id   = "2.3.17.6"
     Task = "(L1) Ensure 'User Account Control: Run all administrators in Admin Approval Mode' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableLUA" `
-                | Select-Object -ExpandProperty "EnableLUA"
+            | Select-Object -ExpandProperty "EnableLUA"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.7"
+    Id   = "2.3.17.7"
     Task = "(L1) Ensure 'User Account Control: Switch to the secure desktop when prompting for elevation' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "PromptOnSecureDesktop" `
-                | Select-Object -ExpandProperty "PromptOnSecureDesktop"
+            | Select-Object -ExpandProperty "PromptOnSecureDesktop"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "2.3.17.8"
+    Id   = "2.3.17.8"
     Task = "(L1) Ensure 'User Account Control: Virtualize file and registry write failures to per-user locations' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableVirtualization" `
-                | Select-Object -ExpandProperty "EnableVirtualization"
+            | Select-Object -ExpandProperty "EnableVirtualization"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.1"
+    Id   = "5.1"
     Task = "(L2) Ensure 'Bluetooth Audio Gateway Service (BTAGService)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\BTAGService" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.2"
+    Id   = "5.2"
     Task = "(L2) Ensure 'Bluetooth Support Service (bthserv)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\bthserv" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.3"
+    Id   = "5.3"
     Task = "(L1) Ensure 'Computer Browser (Browser)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Browser" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.4"
+    Id   = "5.4"
     Task = "(L2) Ensure 'Downloaded Maps Manager (MapsBroker)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MapsBroker" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.5"
+    Id   = "5.5"
     Task = "(L2) Ensure 'Geolocation Service (lfsvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\lfsvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.6"
+    Id   = "5.6"
     Task = "(L1) Ensure 'IIS Admin Service (IISADMIN)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\IISADMIN" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.7"
+    Id   = "5.7"
     Task = "(L1) Ensure 'Infrared monitor service (irmon)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\irmon" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.8"
+    Id   = "5.8"
     Task = "(L1) Ensure 'Internet Connection Sharing (ICS) (SharedAccess)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.9"
+    Id   = "5.9"
     Task = "(L2) Ensure 'Link-Layer Topology Discovery Mapper (lltdsvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\lltdsvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.10"
+    Id   = "5.10"
     Task = "(L1) Ensure 'LxssManager (LxssManager)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LxssManager" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.11"
+    Id   = "5.11"
     Task = "(L1) Ensure 'Microsoft FTP Service (FTPSVC)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\FTPSVC" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.12"
+    Id   = "5.12"
     Task = "(L2) Ensure 'Microsoft iSCSI Initiator Service (MSiSCSI)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MSiSCSI" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.13"
+    Id   = "5.13"
     Task = "(L1) Ensure 'OpenSSH SSH Server (sshd)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\sshd" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.14"
+    Id   = "5.14"
     Task = "(L2) Ensure 'Peer Name Resolution Protocol (PNRPsvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PNRPsvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.15"
+    Id   = "5.15"
     Task = "(L2) Ensure 'Peer Networking Grouping (p2psvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\p2psvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.16"
+    Id   = "5.16"
     Task = "(L2) Ensure 'Peer Networking Identity Manager (p2pimsvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\p2pimsvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.17"
+    Id   = "5.17"
     Task = "(L2) Ensure 'PNRP Machine Name Publication Service (PNRPAutoReg)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PNRPAutoReg" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.18"
+    Id   = "5.18"
     Task = "(L2) Ensure 'Print Spooler (Spooler)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Spooler" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.19"
+    Id   = "5.19"
     Task = "(L2) Ensure 'Problem Reports and Solutions Control Panel Support (wercplsupport)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\wercplsupport" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.20"
+    Id   = "5.20"
     Task = "(L2) Ensure 'Remote Access Auto Connection Manager (RasAuto)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RasAuto" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.21"
+    Id   = "5.21"
     Task = "(L2) Ensure 'Remote Desktop Configuration (SessionEnv)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SessionEnv" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.22"
+    Id   = "5.22"
     Task = "(L2) Ensure 'Remote Desktop Services (TermService)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TermService" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.23"
+    Id   = "5.23"
     Task = "(L2) Ensure 'Remote Desktop Services UserMode Port Redirector (UmRdpService)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\UmRdpService" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.24"
+    Id   = "5.24"
     Task = "(L1) Ensure 'Remote Procedure Call (RPC) Locator (RpcLocator)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RpcLocator" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.25"
+    Id   = "5.25"
     Task = "(L2) Ensure 'Remote Registry (RemoteRegistry)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RemoteRegistry" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.26"
+    Id   = "5.26"
     Task = "(L1) Ensure 'Routing and Remote Access (RemoteAccess)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\RemoteAccess" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.27"
+    Id   = "5.27"
     Task = "(L2) Ensure 'Server (LanmanServer)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.28"
+    Id   = "5.28"
     Task = "(L1) Ensure 'Simple TCP/IP Services (simptcp)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\simptcp" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.29"
+    Id   = "5.29"
     Task = "(L2) Ensure 'SNMP Service (SNMP)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SNMP" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.30"
+    Id   = "5.30"
     Task = "(L1) Ensure 'Special Administration Console Helper (sacsvr)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\sacsvr" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.31"
+    Id   = "5.31"
     Task = "(L1) Ensure 'SSDP Discovery (SSDPSRV)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SSDPSRV" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.32"
+    Id   = "5.32"
     Task = "(L1) Ensure 'UPnP Device Host (upnphost)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\upnphost" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.33"
+    Id   = "5.33"
     Task = "(L1) Ensure 'Web Management Service (WMSvc)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WMSvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.34"
+    Id   = "5.34"
     Task = "(L2) Ensure 'Windows Error Reporting Service (WerSvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WerSvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.35"
+    Id   = "5.35"
     Task = "(L2) Ensure 'Windows Event Collector (Wecsvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Wecsvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.36"
+    Id   = "5.36"
     Task = "(L1) Ensure 'Windows Media Player Network Sharing Service (WMPNetworkSvc)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WMPNetworkSvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.37"
+    Id   = "5.37"
     Task = "(L1) Ensure 'Windows Mobile Hotspot Service (icssvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\icssvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.38"
+    Id   = "5.38"
     Task = "(L2) Ensure 'Windows Push Notifications System Service (WpnService)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WpnService" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.39"
+    Id   = "5.39"
     Task = "(L2) Ensure 'Windows PushToInstall Service (PushToInstall)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PushToInstall" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.40"
+    Id   = "5.40"
     Task = "(L2) Ensure 'Windows Remote Management (WS-Management) (WinRM)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\WinRM" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.41"
+    Id   = "5.41"
     Task = "(L1) Ensure 'World Wide Web Publishing Service (W3SVC)' is set to 'Disabled' or 'Not Installed'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W3SVC" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.42"
+    Id   = "5.42"
     Task = "(L1) Ensure 'Xbox Accessory Management Service (XboxGipSvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XboxGipSvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.43"
+    Id   = "5.43"
     Task = "(L1) Ensure 'Xbox Live Auth Manager (XblAuthManager)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XblAuthManager" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.44"
+    Id   = "5.44"
     Task = "(L1) Ensure 'Xbox Live Game Save (XblGameSave)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XblGameSave" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "5.45"
+    Id   = "5.45"
     Task = "(L1) Ensure 'Xbox Live Networking Service (XboxNetApiSvc)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\XboxNetApiSvc" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.1"
+    Id   = "9.2.1"
     Task = "(L1) Ensure 'Windows Firewall: Private: Firewall state' is set to 'On (recommended)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile" `
                 -Name "EnableFirewall" `
-                | Select-Object -ExpandProperty "EnableFirewall"
+            | Select-Object -ExpandProperty "EnableFirewall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.2"
+    Id   = "9.2.2"
     Task = "(L1) Ensure 'Windows Firewall: Private: Inbound connections' is set to 'Block (default)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile" `
                 -Name "DefaultInboundAction" `
-                | Select-Object -ExpandProperty "DefaultInboundAction"
+            | Select-Object -ExpandProperty "DefaultInboundAction"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.3"
+    Id   = "9.2.3"
     Task = "(L1) Ensure 'Windows Firewall: Private: Outbound connections' is set to 'Allow (default)'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile"
@@ -3676,12 +3676,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.4"
+    Id   = "9.2.4"
     Task = "(L1) Ensure 'Windows Firewall: Private: Settings: Display a notification' is set to 'No'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile"
@@ -3692,12 +3692,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.5"
+    Id   = "9.2.5"
     Task = "(L1) Ensure 'Windows Firewall: Private: Logging: Name' is set to '%SystemRoot%\System32\logfiles\firewall\privatefw.log'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging"
@@ -3708,12 +3708,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.6"
+    Id   = "9.2.6"
     Task = "(L1) Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is set to '16,384 KB or greater'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging"
@@ -3724,12 +3724,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.7"
+    Id   = "9.2.7"
     Task = "(L1) Ensure 'Windows Firewall: Private: Logging: Log dropped packets' is set to 'Yes'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging"
@@ -3740,12 +3740,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.2.8"
+    Id   = "9.2.8"
     Task = "(L1) Ensure 'Windows Firewall: Private: Logging: Log successful connections' is set to 'Yes'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging"
@@ -3756,12 +3756,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.1"
+    Id   = "9.3.1"
     Task = "(L1) Ensure 'Windows Firewall: Public: Firewall state' is set to 'On (recommended)'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile"
@@ -3772,12 +3772,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.2"
+    Id   = "9.3.2"
     Task = "(L1) Ensure 'Windows Firewall: Public: Inbound connections' is set to 'Block (default)'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile"
@@ -3788,12 +3788,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.3"
+    Id   = "9.3.3"
     Task = "(L1) Ensure 'Windows Firewall: Public: Outbound connections' is set to 'Allow (default)'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile"
@@ -3804,12 +3804,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.4"
+    Id   = "9.3.4"
     Task = "(L1) Ensure 'Windows Firewall: Public: Settings: Display a notification' is set to 'No'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile"
@@ -3820,12 +3820,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.5"
+    Id   = "9.3.5"
     Task = "(L1) Ensure 'Windows Firewall: Public: Settings: Apply local firewall rules' is set to 'No'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile"
@@ -3836,12 +3836,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.6"
+    Id   = "9.3.6"
     Task = "(L1) Ensure 'Windows Firewall: Public: Settings: Apply local connection security rules' is set to 'No'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile"
@@ -3852,12 +3852,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.7"
+    Id   = "9.3.7"
     Task = "(L1) Ensure 'Windows Firewall: Public: Logging: Name' is set to '%SystemRoot%\System32\logfiles\firewall\publicfw.log'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging"
@@ -3868,12 +3868,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.8"
+    Id   = "9.3.8"
     Task = "(L1) Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is set to '16,384 KB or greater'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging"
@@ -3884,12 +3884,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.9"
+    Id   = "9.3.9"
     Task = "(L1) Ensure 'Windows Firewall: Public: Logging: Log dropped packets' is set to 'Yes'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging"
@@ -3900,12 +3900,12 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "9.3.10"
+    Id   = "9.3.10"
     Task = "(L1) Ensure 'Windows Firewall: Public: Logging: Log successful connections' is set to 'Yes'"
     Test = {
         $path1 = "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging"
@@ -3916,1431 +3916,1431 @@ $windefrunning = CheckWindefRunning
         $result = $path1, $path2 | Test-FirewallPaths -Key $key -ExpectedValue $expectedValue -ProfileType $profileType
         return @{
             Message = $($result.Message)
-            Status = $($result.Status)
+            Status  = $($result.Status)
         }
     }
 }
 [AuditTest] @{
-    Id = "18.1.1.1"
+    Id   = "18.1.1.1"
     Task = "(L1) Ensure 'Prevent enabling lock screen camera' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Personalization" `
                 -Name "NoLockScreenCamera" `
-                | Select-Object -ExpandProperty "NoLockScreenCamera"
+            | Select-Object -ExpandProperty "NoLockScreenCamera"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.1.1.2"
+    Id   = "18.1.1.2"
     Task = "(L1) Ensure 'Prevent enabling lock screen slide show' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Personalization" `
                 -Name "NoLockScreenSlideshow" `
-                | Select-Object -ExpandProperty "NoLockScreenSlideshow"
+            | Select-Object -ExpandProperty "NoLockScreenSlideshow"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.1.2.2"
+    Id   = "18.1.2.2"
     Task = "(L1) Ensure 'Allow users to enable online speech recognition services' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\InputPersonalization" `
                 -Name "AllowInputPersonalization" `
-                | Select-Object -ExpandProperty "AllowInputPersonalization"
+            | Select-Object -ExpandProperty "AllowInputPersonalization"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.1.3"
+    Id   = "18.1.3"
     Task = "(L2) Ensure 'Allow Online Tips' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "AllowOnlineTips" `
-                | Select-Object -ExpandProperty "AllowOnlineTips"
+            | Select-Object -ExpandProperty "AllowOnlineTips"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.1"
+    Id   = "18.4.1"
     Task = "(L1) Ensure 'Configure RPC packet level privacy setting for incoming connections' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print" `
                 -Name "RpcAuthnLevelPrivacyEnabled" `
-                | Select-Object -ExpandProperty "RpcAuthnLevelPrivacyEnabled"
+            | Select-Object -ExpandProperty "RpcAuthnLevelPrivacyEnabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.2"
+    Id   = "18.4.2"
     Task = "(L1) Ensure 'Configure SMB v1 client driver' is set to 'Enabled: Disable driver (recommended)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\mrxsmb10" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.3"
+    Id   = "18.4.3"
     Task = "(L1) Ensure 'Configure SMB v1 server' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" `
                 -Name "SMB1" `
-                | Select-Object -ExpandProperty "SMB1"
+            | Select-Object -ExpandProperty "SMB1"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.4"
+    Id   = "18.4.4"
     Task = "(L1) Ensure 'Enable Structured Exception Handling Overwrite Protection (SEHOP)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\kernel" `
                 -Name "DisableExceptionChainValidation" `
-                | Select-Object -ExpandProperty "DisableExceptionChainValidation"
+            | Select-Object -ExpandProperty "DisableExceptionChainValidation"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.5"
+    Id   = "18.4.5"
     Task = "(L1) Ensure 'LSA Protection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "RunAsPPL" `
-                | Select-Object -ExpandProperty "RunAsPPL"
+            | Select-Object -ExpandProperty "RunAsPPL"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.6"
+    Id   = "18.4.6"
     Task = "(L1) Ensure 'NetBT NodeType configuration' is set to 'Enabled: P-node (recommended)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\NetBT\Parameters" `
                 -Name "NodeType" `
-                | Select-Object -ExpandProperty "NodeType"
+            | Select-Object -ExpandProperty "NodeType"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.4.7"
+    Id   = "18.4.7"
     Task = "(L1) Ensure 'WDigest Authentication' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest" `
                 -Name "UseLogonCredential" `
-                | Select-Object -ExpandProperty "UseLogonCredential"
+            | Select-Object -ExpandProperty "UseLogonCredential"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.1"
+    Id   = "18.5.1"
     Task = "(L1) Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon (not recommended)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" `
                 -Name "AutoAdminLogon" `
-                | Select-Object -ExpandProperty "AutoAdminLogon"
+            | Select-Object -ExpandProperty "AutoAdminLogon"
         
             if ($regValue -ne "0") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.2"
+    Id   = "18.5.2"
     Task = "(L1) Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level (protects against packet spoofing)' is set to 'Enabled: Highest protection, source routing is completely disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip6\Parameters" `
                 -Name "DisableIPSourceRouting" `
-                | Select-Object -ExpandProperty "DisableIPSourceRouting"
+            | Select-Object -ExpandProperty "DisableIPSourceRouting"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.3"
+    Id   = "18.5.3"
     Task = "(L1) Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level (protects against packet spoofing)' is set to 'Enabled: Highest protection, source routing is completely disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "DisableIPSourceRouting" `
-                | Select-Object -ExpandProperty "DisableIPSourceRouting"
+            | Select-Object -ExpandProperty "DisableIPSourceRouting"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.4"
+    Id   = "18.5.4"
     Task = "(L2) Ensure 'MSS: (DisableSavePassword) Prevent the dial-up password from being saved' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\RasMan\Parameters" `
                 -Name "disablesavepassword" `
-                | Select-Object -ExpandProperty "disablesavepassword"
+            | Select-Object -ExpandProperty "disablesavepassword"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.5"
+    Id   = "18.5.5"
     Task = "(L1) Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "EnableICMPRedirect" `
-                | Select-Object -ExpandProperty "EnableICMPRedirect"
+            | Select-Object -ExpandProperty "EnableICMPRedirect"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.6"
+    Id   = "18.5.6"
     Task = "(L2) Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sent in milliseconds' is set to 'Enabled: 300,000 or 5 minutes (recommended)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "KeepAliveTime" `
-                | Select-Object -ExpandProperty "KeepAliveTime"
+            | Select-Object -ExpandProperty "KeepAliveTime"
         
             if ($regValue -ne 300000) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 300000"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.7"
+    Id   = "18.5.7"
     Task = "(L1) Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\NetBT\Parameters" `
                 -Name "nonamereleaseondemand" `
-                | Select-Object -ExpandProperty "nonamereleaseondemand"
+            | Select-Object -ExpandProperty "nonamereleaseondemand"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.8"
+    Id   = "18.5.8"
     Task = "(L2) Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and configure Default Gateway addresses (could lead to DoS)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "PerformRouterDiscovery" `
-                | Select-Object -ExpandProperty "PerformRouterDiscovery"
+            | Select-Object -ExpandProperty "PerformRouterDiscovery"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.9"
+    Id   = "18.5.9"
     Task = "(L1) Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode (recommended)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager" `
                 -Name "SafeDllSearchMode" `
-                | Select-Object -ExpandProperty "SafeDllSearchMode"
+            | Select-Object -ExpandProperty "SafeDllSearchMode"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.10"
+    Id   = "18.5.10"
     Task = "(L1) Ensure 'MSS: (ScreenSaverGracePeriod) The time in seconds before the screen saver grace period expires (0 recommended)' is set to 'Enabled: 5 or fewer seconds'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" `
                 -Name "ScreenSaverGracePeriod" `
-                | Select-Object -ExpandProperty "ScreenSaverGracePeriod"
+            | Select-Object -ExpandProperty "ScreenSaverGracePeriod"
         
             if ($regValue -notmatch "^[0-5]$") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: Matching expression '^[0-5]$'"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.11"
+    Id   = "18.5.11"
     Task = "(L2) Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\TCPIP6\Parameters" `
                 -Name "tcpmaxdataretransmissions" `
-                | Select-Object -ExpandProperty "tcpmaxdataretransmissions"
+            | Select-Object -ExpandProperty "tcpmaxdataretransmissions"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.12"
+    Id   = "18.5.12"
     Task = "(L2) Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowledged data is retransmitted' is set to 'Enabled: 3'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "tcpmaxdataretransmissions" `
-                | Select-Object -ExpandProperty "tcpmaxdataretransmissions"
+            | Select-Object -ExpandProperty "tcpmaxdataretransmissions"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.5.13"
+    Id   = "18.5.13"
     Task = "(L1) Ensure 'MSS: (WarningLevel) Percentage threshold for the security event log at which the system will generate a warning' is set to 'Enabled: 90% or less'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Eventlog\Security" `
                 -Name "WarningLevel" `
-                | Select-Object -ExpandProperty "WarningLevel"
+            | Select-Object -ExpandProperty "WarningLevel"
         
             if (($regValue -gt 90)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x <= 90"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.4.1"
+    Id   = "18.6.4.1"
     Task = "(L1) Ensure 'Configure NetBIOS settings' is set to 2 - 'Enabled: Disable NetBIOS name resolution on public networks' (or 0 - Disable NetBIOS name resolution)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient" `
                 -Name "EnableNetbios" `
-                | Select-Object -ExpandProperty "EnableNetbios"
+            | Select-Object -ExpandProperty "EnableNetbios"
         
             if (($regValue -ne 2) -and ($regValue -ne 0)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 2 or x == 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.4.2"
+    Id   = "18.6.4.2"
     Task = "(L1) Ensure 'Turn off multicast name resolution' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient" `
                 -Name "EnableMulticast" `
-                | Select-Object -ExpandProperty "EnableMulticast"
+            | Select-Object -ExpandProperty "EnableMulticast"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.5.1"
+    Id   = "18.6.5.1"
     Task = "(L2) Ensure 'Enable Font Providers' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "EnableFontProviders" `
-                | Select-Object -ExpandProperty "EnableFontProviders"
+            | Select-Object -ExpandProperty "EnableFontProviders"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.8.1"
+    Id   = "18.6.8.1"
     Task = "(L1) Ensure 'Enable insecure guest logons' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LanmanWorkstation" `
                 -Name "AllowInsecureGuestAuth" `
-                | Select-Object -ExpandProperty "AllowInsecureGuestAuth"
+            | Select-Object -ExpandProperty "AllowInsecureGuestAuth"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.1 A"
+    Id   = "18.6.9.1 A"
     Task = "(L2) Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled' (Domain network)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "AllowLLTDIOOnDomain" `
-                | Select-Object -ExpandProperty "AllowLLTDIOOnDomain"
+            | Select-Object -ExpandProperty "AllowLLTDIOOnDomain"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.1 B"
+    Id   = "18.6.9.1 B"
     Task = "(L2) Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled' (Public network)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "AllowLLTDIOOnPublicNet" `
-                | Select-Object -ExpandProperty "AllowLLTDIOOnPublicNet"
+            | Select-Object -ExpandProperty "AllowLLTDIOOnPublicNet"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.1 C"
+    Id   = "18.6.9.1 C"
     Task = "(L2) Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled' (EnableLLTDIO)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "EnableLLTDIO" `
-                | Select-Object -ExpandProperty "EnableLLTDIO"
+            | Select-Object -ExpandProperty "EnableLLTDIO"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.1 D"
+    Id   = "18.6.9.1 D"
     Task = "(L2) Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled' (Private network)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "ProhibitLLTDIOOnPrivateNet" `
-                | Select-Object -ExpandProperty "ProhibitLLTDIOOnPrivateNet"
+            | Select-Object -ExpandProperty "ProhibitLLTDIOOnPrivateNet"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.2 A"
+    Id   = "18.6.9.2 A"
     Task = "(L2) Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled' (Domain network)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "AllowRspndrOnDomain" `
-                | Select-Object -ExpandProperty "AllowRspndrOnDomain"
+            | Select-Object -ExpandProperty "AllowRspndrOnDomain"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.2 B"
+    Id   = "18.6.9.2 B"
     Task = "(L2) Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled' (Public network)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "AllowRspndrOnPublicNet" `
-                | Select-Object -ExpandProperty "AllowRspndrOnPublicNet"
+            | Select-Object -ExpandProperty "AllowRspndrOnPublicNet"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.2 C"
+    Id   = "18.6.9.2 C"
     Task = "(L2) Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled' (EnableRspndr)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "EnableRspndr" `
-                | Select-Object -ExpandProperty "EnableRspndr"
+            | Select-Object -ExpandProperty "EnableRspndr"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.9.2 D"
+    Id   = "18.6.9.2 D"
     Task = "(L2) Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled' (Private network)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LLTD" `
                 -Name "ProhibitRspndrOnPrivateNet" `
-                | Select-Object -ExpandProperty "ProhibitRspndrOnPrivateNet"
+            | Select-Object -ExpandProperty "ProhibitRspndrOnPrivateNet"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.10.2"
+    Id   = "18.6.10.2"
     Task = "(L2) Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Peernet" `
                 -Name "Disabled" `
-                | Select-Object -ExpandProperty "Disabled"
+            | Select-Object -ExpandProperty "Disabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.11.2"
+    Id   = "18.6.11.2"
     Task = "(L1) Ensure 'Prohibit installation and configuration of Network Bridge on your DNS domain network' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections" `
                 -Name "NC_AllowNetBridge_NLA" `
-                | Select-Object -ExpandProperty "NC_AllowNetBridge_NLA"
+            | Select-Object -ExpandProperty "NC_AllowNetBridge_NLA"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.11.3"
+    Id   = "18.6.11.3"
     Task = "(L1) Ensure 'Prohibit use of Internet Connection Sharing on your DNS domain network' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Network Connections" `
                 -Name "NC_ShowSharedAccessUI" `
-                | Select-Object -ExpandProperty "NC_ShowSharedAccessUI"
+            | Select-Object -ExpandProperty "NC_ShowSharedAccessUI"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.14.1 A"
+    Id   = "18.6.14.1 A"
     Task = "(L1) Ensure 'Hardened UNC Paths' is set to 'Enabled, with `"Require Mutual Authentication`" and `"Require Integrity`" set for all NETLOGON and SYSVOL shares' (\\*\NETLOGON)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths" `
                 -Name "\\*\NETLOGON" `
-                | Select-Object -ExpandProperty "\\*\NETLOGON"
+            | Select-Object -ExpandProperty "\\*\NETLOGON"
         
-            if($regValue -eq $null){
+            if ($regValue -eq $null) {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
-            $array = $regValue.Split(',') | ForEach-Object{ $_.Trim() }
+            $array = $regValue.Split(',') | ForEach-Object { $_.Trim() }
 
             $missingElements = @()
             $elementsToCheck = @("RequireMutualAuthentication=1", "RequireIntegrity=1")
@@ -5353,46 +5353,46 @@ $windefrunning = CheckWindefRunning
             if ($missingElements.Length -gt 0) {
                 return @{
                     Message = ($missingElements -join " and ") + " not configured correctly."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.14.1 B"
+    Id   = "18.6.14.1 B"
     Task = "(L1) Ensure 'Hardened UNC Paths' is set to 'Enabled, with `"Require Mutual Authentication`" and `"Require Integrity`" set for all NETLOGON and SYSVOL shares' (\\*\SYSVOL)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths" `
                 -Name "\\*\SYSVOL" `
-                | Select-Object -ExpandProperty "\\*\SYSVOL"
+            | Select-Object -ExpandProperty "\\*\SYSVOL"
         
-            if($regValue -eq $null){
+            if ($regValue -eq $null) {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
-            $array = $regValue.Split(',') | ForEach-Object{ $_.Trim() }
+            $array = $regValue.Split(',') | ForEach-Object { $_.Trim() }
 
             $missingElements = @()
             $elementsToCheck = @("RequireMutualAuthentication=1", "RequireIntegrity=1")
@@ -5405,4988 +5405,4988 @@ $windefrunning = CheckWindefRunning
             if ($missingElements.Length -gt 0) {
                 return @{
                     Message = ($missingElements -join " and ") + " not configured correctly."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.19.2.1"
+    Id   = "18.6.19.2.1"
     Task = "(L2) Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set to '0xff (255)')"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\TCPIP6\Parameters" `
                 -Name "DisabledComponents" `
-                | Select-Object -ExpandProperty "DisabledComponents"
+            | Select-Object -ExpandProperty "DisabledComponents"
         
             if (($regValue -ne 255)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 255"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.20.1 A"
+    Id   = "18.6.20.1 A"
     Task = "(L2) Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled' (EnableRegistrars)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WCN\Registrars" `
                 -Name "EnableRegistrars" `
-                | Select-Object -ExpandProperty "EnableRegistrars"
+            | Select-Object -ExpandProperty "EnableRegistrars"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.20.1 B"
+    Id   = "18.6.20.1 B"
     Task = "(L2) Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled' (DisableUPnPRegistrar)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WCN\Registrars" `
                 -Name "DisableUPnPRegistrar" `
-                | Select-Object -ExpandProperty "DisableUPnPRegistrar"
+            | Select-Object -ExpandProperty "DisableUPnPRegistrar"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.20.1 C"
+    Id   = "18.6.20.1 C"
     Task = "(L2) Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled' (DisableInBand802DOT11Registrar)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WCN\Registrars" `
                 -Name "DisableInBand802DOT11Registrar" `
-                | Select-Object -ExpandProperty "DisableInBand802DOT11Registrar"
+            | Select-Object -ExpandProperty "DisableInBand802DOT11Registrar"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.20.1 D"
+    Id   = "18.6.20.1 D"
     Task = "(L2) Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled' (DisableFlashConfigRegistrar)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WCN\Registrars" `
                 -Name "DisableFlashConfigRegistrar" `
-                | Select-Object -ExpandProperty "DisableFlashConfigRegistrar"
+            | Select-Object -ExpandProperty "DisableFlashConfigRegistrar"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.20.1 E"
+    Id   = "18.6.20.1 E"
     Task = "(L2) Ensure 'Configuration of wireless settings using Windows Connect Now' is set to 'Disabled' (DisableWPDRegistrar)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WCN\Registrars" `
                 -Name "DisableWPDRegistrar" `
-                | Select-Object -ExpandProperty "DisableWPDRegistrar"
+            | Select-Object -ExpandProperty "DisableWPDRegistrar"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.20.2"
+    Id   = "18.6.20.2"
     Task = "(L2) Ensure 'Prohibit access of the Windows Connect Now wizards' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WCN\UI" `
                 -Name "DisableWcnUi" `
-                | Select-Object -ExpandProperty "DisableWcnUi"
+            | Select-Object -ExpandProperty "DisableWcnUi"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.21.1"
+    Id   = "18.6.21.1"
     Task = "(L1) Ensure 'Minimize the number of simultaneous connections to the Internet or a Windows Domain' is set to 'Enabled: 3 = Prevent Wi-Fi when on Ethernet'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WcmSvc\GroupPolicy" `
                 -Name "fMinimizeConnections" `
-                | Select-Object -ExpandProperty "fMinimizeConnections"
+            | Select-Object -ExpandProperty "fMinimizeConnections"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.6.23.2.1"
+    Id   = "18.6.23.2.1"
     Task = "(L1) Ensure 'Allow Windows to automatically connect to suggested open hotspots, to networks shared by contacts, and to hotspots offering paid services' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WcmSvc\wifinetworkmanager\config" `
                 -Name "AutoConnectAllowedOEM" `
-                | Select-Object -ExpandProperty "AutoConnectAllowedOEM"
+            | Select-Object -ExpandProperty "AutoConnectAllowedOEM"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.1"
+    Id   = "18.7.1"
     Task = "(L1) Ensure 'Allow Print Spooler to accept client connections' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers" `
                 -Name "RegisterSpoolerRemoteRpcEndPoint" `
-                | Select-Object -ExpandProperty "RegisterSpoolerRemoteRpcEndPoint"
+            | Select-Object -ExpandProperty "RegisterSpoolerRemoteRpcEndPoint"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.2"
+    Id   = "18.7.2"
     Task = "(L1) Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirection Guard Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers" `
                 -Name "RedirectionGuardPolicy" `
-                | Select-Object -ExpandProperty "RedirectionGuardPolicy"
+            | Select-Object -ExpandProperty "RedirectionGuardPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.3"
+    Id   = "18.7.3"
     Task = "(L1) Ensure 'Configure RPC connection settings: Protocol to use for outgoing RPC connections' is set to 'Enabled: RPC over TCP'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcUseNamedPipeProtocol" `
-                | Select-Object -ExpandProperty "RpcUseNamedPipeProtocol"
+            | Select-Object -ExpandProperty "RpcUseNamedPipeProtocol"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.4"
+    Id   = "18.7.4"
     Task = "(L1) Ensure 'Configure RPC connection settings: Use authentication for outgoing RPC connections' is set to 'Enabled: Default'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcAuthentication" `
-                | Select-Object -ExpandProperty "RpcAuthentication"
+            | Select-Object -ExpandProperty "RpcAuthentication"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.5"
+    Id   = "18.7.5"
     Task = "(L1) Ensure 'Configure RPC listener settings: Protocols to allow for incoming RPC connections' is set to 'Enabled: RPC over TCP'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcProtocols" `
-                | Select-Object -ExpandProperty "RpcProtocols"
+            | Select-Object -ExpandProperty "RpcProtocols"
         
             if ($regValue -ne 5) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 5"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.6"
+    Id   = "18.7.6"
     Task = "(L1) Ensure 'Configure RPC listener settings: Authentication protocol to use for incoming RPC connections:' is set to 'Enabled: Negotiate' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "ForceKerberosForRpc" `
-                | Select-Object -ExpandProperty "ForceKerberosForRpc"
+            | Select-Object -ExpandProperty "ForceKerberosForRpc"
         
             if (($regValue -ne 0) -and ($regValue -ne 1)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 0 or x == 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.7"
+    Id   = "18.7.7"
     Task = "(L1) Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcTcpPort" `
-                | Select-Object -ExpandProperty "RpcTcpPort"
+            | Select-Object -ExpandProperty "RpcTcpPort"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.8"
+    Id   = "18.7.8"
     Task = "(L1) Ensure 'Limits print driver installation to Administrators' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint" `
                 -Name "RestrictDriverInstallationToAdministrators" `
-                | Select-Object -ExpandProperty "RestrictDriverInstallationToAdministrators"
+            | Select-Object -ExpandProperty "RestrictDriverInstallationToAdministrators"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.9"
+    Id   = "18.7.9"
     Task = "(L1) Ensure 'Manage processing of Queue-specific files' is set to 'Enabled: Limit Queue-specific files to Color profiles'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers" `
                 -Name "CopyFilesPolicy" `
-                | Select-Object -ExpandProperty "CopyFilesPolicy"
+            | Select-Object -ExpandProperty "CopyFilesPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.10"
+    Id   = "18.7.10"
     Task = "(L1) Ensure 'Point and Print Restrictions: When installing drivers for a new connection' is set to 'Enabled: Show warning and elevation prompt'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint" `
                 -Name "NoWarningNoElevationOnInstall" `
-                | Select-Object -ExpandProperty "NoWarningNoElevationOnInstall"
+            | Select-Object -ExpandProperty "NoWarningNoElevationOnInstall"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.7.11"
+    Id   = "18.7.11"
     Task = "(L1) Ensure 'Point and Print Restrictions: When updating drivers for an existing connection' is set to 'Enabled: Show warning and elevation prompt'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint" `
                 -Name "UpdatePromptSettings" `
-                | Select-Object -ExpandProperty "UpdatePromptSettings"
+            | Select-Object -ExpandProperty "UpdatePromptSettings"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.8.1.1"
+    Id   = "18.8.1.1"
     Task = "(L2) Ensure 'Turn off notifications network usage' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications" `
                 -Name "NoCloudApplicationNotification" `
-                | Select-Object -ExpandProperty "NoCloudApplicationNotification"
+            | Select-Object -ExpandProperty "NoCloudApplicationNotification"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.3.1"
+    Id   = "18.9.3.1"
     Task = "(L1) Ensure 'Include command line in process creation events' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit" `
                 -Name "ProcessCreationIncludeCmdLine_Enabled" `
-                | Select-Object -ExpandProperty "ProcessCreationIncludeCmdLine_Enabled"
+            | Select-Object -ExpandProperty "ProcessCreationIncludeCmdLine_Enabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.4.1"
+    Id   = "18.9.4.1"
     Task = "(L1) Ensure 'Encryption Oracle Remediation' is set to 'Enabled: Force Updated Clients'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters" `
                 -Name "AllowEncryptionOracle" `
-                | Select-Object -ExpandProperty "AllowEncryptionOracle"
+            | Select-Object -ExpandProperty "AllowEncryptionOracle"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.4.2"
+    Id   = "18.9.4.2"
     Task = "(L1) Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CredentialsDelegation" `
                 -Name "AllowProtectedCreds" `
-                | Select-Object -ExpandProperty "AllowProtectedCreds"
+            | Select-Object -ExpandProperty "AllowProtectedCreds"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.5.1"
+    Id   = "18.9.5.1"
     Task = "(NG) Ensure 'Turn On Virtualization Based Security' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "EnableVirtualizationBasedSecurity" `
-                | Select-Object -ExpandProperty "EnableVirtualizationBasedSecurity"
+            | Select-Object -ExpandProperty "EnableVirtualizationBasedSecurity"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.5.2"
+    Id   = "18.9.5.2"
     Task = "(NG) Ensure 'Turn On Virtualization Based Security: Select Platform Security Level' is set to 'Secure Boot' or higher"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "RequirePlatformSecurityFeatures" `
-                | Select-Object -ExpandProperty "RequirePlatformSecurityFeatures"
+            | Select-Object -ExpandProperty "RequirePlatformSecurityFeatures"
         
             if (($regValue -ne 1) -and ($regValue -ne 3)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 1 or x == 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.5.3"
+    Id   = "18.9.5.3"
     Task = "(NG) Ensure 'Turn On Virtualization Based Security: Virtualization Based Protection of Code Integrity' is set to 'Enabled with UEFI lock'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "HypervisorEnforcedCodeIntegrity" `
-                | Select-Object -ExpandProperty "HypervisorEnforcedCodeIntegrity"
+            | Select-Object -ExpandProperty "HypervisorEnforcedCodeIntegrity"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.5.4"
+    Id   = "18.9.5.4"
     Task = "(NG) Ensure 'Turn On Virtualization Based Security: Require UEFI Memory Attributes Table' is set to 'True (checked)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "HVCIMATRequired" `
-                | Select-Object -ExpandProperty "HVCIMATRequired"
+            | Select-Object -ExpandProperty "HVCIMATRequired"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.5.5"
+    Id   = "18.9.5.5"
     Task = "(NG) Ensure 'Turn On Virtualization Based Security: Credential Guard Configuration' is set to 'Enabled with UEFI lock'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "LsaCfgFlags" `
-                | Select-Object -ExpandProperty "LsaCfgFlags"
+            | Select-Object -ExpandProperty "LsaCfgFlags"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.5.6"
+    Id   = "18.9.5.6"
     Task = "(NG) Ensure 'Turn On Virtualization Based Security: Secure Launch Configuration' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "ConfigureSystemGuardLaunch" `
-                | Select-Object -ExpandProperty "ConfigureSystemGuardLaunch"
+            | Select-Object -ExpandProperty "ConfigureSystemGuardLaunch"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.1"
+    Id   = "18.9.7.1.1"
     Task = "(BL) Ensure 'Prevent installation of devices that match any of these device IDs' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions" `
                 -Name "DenyDeviceIDs" `
-                | Select-Object -ExpandProperty "DenyDeviceIDs"
+            | Select-Object -ExpandProperty "DenyDeviceIDs"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.2"
+    Id   = "18.9.7.1.2"
     Task = "(BL) Ensure 'Prevent installation of devices that match any of these device IDs: Prevent installation of devices that match any of these device IDs' is set to 'PCI\CC_0C0A'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceIDs" `
                 -Name "1" `
-                | Select-Object -ExpandProperty "1"
+            | Select-Object -ExpandProperty "1"
         
             if ($regValue -ne "PCI\CC_0C0A") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: PCI\CC_0C0A"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.3"
+    Id   = "18.9.7.1.3"
     Task = "(BL) Ensure 'Prevent installation of devices that match any of these device IDs: Also apply to matching devices that are already installed.' is set to 'True' (checked)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions" `
                 -Name "DenyDeviceIDsRetroactive" `
-                | Select-Object -ExpandProperty "DenyDeviceIDsRetroactive"
+            | Select-Object -ExpandProperty "DenyDeviceIDsRetroactive"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.4"
+    Id   = "18.9.7.1.4"
     Task = "(BL) Ensure 'Prevent installation of devices using drivers that match these device setup classes' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions" `
                 -Name "DenyDeviceClasses" `
-                | Select-Object -ExpandProperty "DenyDeviceClasses"
+            | Select-Object -ExpandProperty "DenyDeviceClasses"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.5 A"
+    Id   = "18.9.7.1.5 A"
     Task = "(BL) Ensure 'Prevent installation of devices using drivers that match these device setup classes: Prevent installation of devices using drivers for these device setup' is set to 'IEEE 1394 device setup classes' [IEEE 1394 devices that support the SBP2 Protocol Class]"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses" `
                 -Name "1" `
-                | Select-Object -ExpandProperty "1"
+            | Select-Object -ExpandProperty "1"
         
             if ($regValue -ne "{d48179be-ec20-11d1-b6b8-00c04fa372a7}") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: {d48179be-ec20-11d1-b6b8-00c04fa372a7}"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.5 B"
+    Id   = "18.9.7.1.5 B"
     Task = "(BL) Ensure 'Prevent installation of devices using drivers that match these device setup classes: Prevent installation of devices using drivers for these device setup' is set to 'IEEE 1394 device setup classes' [IEEE 1394 devices that support the IEC-61883 Protocol Class]"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses" `
                 -Name "2" `
-                | Select-Object -ExpandProperty "2"
+            | Select-Object -ExpandProperty "2"
         
             if ($regValue -ne "{7ebefbc0-3200-11d2-b4c2-00a0C9697d07}") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: {7ebefbc0-3200-11d2-b4c2-00a0C9697d07}"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.5 C"
+    Id   = "18.9.7.1.5 C"
     Task = "(BL) Ensure 'Prevent installation of devices using drivers that match these device setup classes: Prevent installation of devices using drivers for these device setup' is set to 'IEEE 1394 device setup classes' [IEEE 1394 devices that support the AVC Protocol Class]"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses" `
                 -Name "3" `
-                | Select-Object -ExpandProperty "3"
+            | Select-Object -ExpandProperty "3"
         
             if ($regValue -ne "{c06ff265-ae09-48f0-812c-16753d7cba83}") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: {c06ff265-ae09-48f0-812c-16753d7cba83}"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.5 D"
+    Id   = "18.9.7.1.5 D"
     Task = "(BL) Ensure 'Prevent installation of devices using drivers that match these device setup classes: Prevent installation of devices using drivers for these device setup' is set to 'IEEE 1394 device setup classes' [IEEE 1394 Host Bus Controller Class]"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses" `
                 -Name "4" `
-                | Select-Object -ExpandProperty "4"
+            | Select-Object -ExpandProperty "4"
         
             if ($regValue -ne "{6bdd1fc1-810f-11d0-bec7-08002be2092f}") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: {6bdd1fc1-810f-11d0-bec7-08002be2092f}"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.1.6"
+    Id   = "18.9.7.1.6"
     Task = "(BL) Ensure 'Prevent installation of devices using drivers that match these device setup classes: Also apply to matching devices that are already installed.' is set to 'True' (checked)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions" `
                 -Name "DenyDeviceClassesRetroactive" `
-                | Select-Object -ExpandProperty "DenyDeviceClassesRetroactive"
+            | Select-Object -ExpandProperty "DenyDeviceClassesRetroactive"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.7.2"
+    Id   = "18.9.7.2"
     Task = "(L1) Ensure 'Prevent device metadata retrieval from the Internet' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Device Metadata" `
                 -Name "PreventDeviceMetadataFromNetwork" `
-                | Select-Object -ExpandProperty "PreventDeviceMetadataFromNetwork"
+            | Select-Object -ExpandProperty "PreventDeviceMetadataFromNetwork"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.13.1"
+    Id   = "18.9.13.1"
     Task = "(L1) Ensure 'Boot-Start Driver Initialization Policy' is set to 'Enabled: Good, unknown and bad but critical'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Policies\EarlyLaunch" `
                 -Name "DriverLoadPolicy" `
-                | Select-Object -ExpandProperty "DriverLoadPolicy"
+            | Select-Object -ExpandProperty "DriverLoadPolicy"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.19.2"
+    Id   = "18.9.19.2"
     Task = "(L1) Ensure 'Continue experiences on this device' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "EnableCdp" `
-                | Select-Object -ExpandProperty "EnableCdp"
+            | Select-Object -ExpandProperty "EnableCdp"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.1"
+    Id   = "18.9.20.1.1"
     Task = "(L2) Ensure 'Turn off access to the Store' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Explorer" `
                 -Name "NoUseStoreOpenWith" `
-                | Select-Object -ExpandProperty "NoUseStoreOpenWith"
+            | Select-Object -ExpandProperty "NoUseStoreOpenWith"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.2"
+    Id   = "18.9.20.1.2"
     Task = "(L1) Ensure 'Turn off downloading of print drivers over HTTP' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers" `
                 -Name "DisableWebPnPDownload" `
-                | Select-Object -ExpandProperty "DisableWebPnPDownload"
+            | Select-Object -ExpandProperty "DisableWebPnPDownload"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.3"
+    Id   = "18.9.20.1.3"
     Task = "(L2) Ensure 'Turn off handwriting personalization data sharing' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\TabletPC" `
                 -Name "PreventHandwritingDataSharing" `
-                | Select-Object -ExpandProperty "PreventHandwritingDataSharing"
+            | Select-Object -ExpandProperty "PreventHandwritingDataSharing"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.4"
+    Id   = "18.9.20.1.4"
     Task = "(L2) Ensure 'Turn off handwriting recognition error reporting' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\HandwritingErrorReports" `
                 -Name "PreventHandwritingErrorReports" `
-                | Select-Object -ExpandProperty "PreventHandwritingErrorReports"
+            | Select-Object -ExpandProperty "PreventHandwritingErrorReports"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.5"
+    Id   = "18.9.20.1.5"
     Task = "(L2) Ensure 'Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Internet Connection Wizard" `
                 -Name "ExitOnMSICW" `
-                | Select-Object -ExpandProperty "ExitOnMSICW"
+            | Select-Object -ExpandProperty "ExitOnMSICW"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.6"
+    Id   = "18.9.20.1.6"
     Task = "(L1) Ensure 'Turn off Internet download for Web publishing and online ordering wizards' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoWebServices" `
-                | Select-Object -ExpandProperty "NoWebServices"
+            | Select-Object -ExpandProperty "NoWebServices"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.7"
+    Id   = "18.9.20.1.7"
     Task = "(L2) Ensure 'Turn off printing over HTTP' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers" `
                 -Name "DisableHTTPPrinting" `
-                | Select-Object -ExpandProperty "DisableHTTPPrinting"
+            | Select-Object -ExpandProperty "DisableHTTPPrinting"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.8"
+    Id   = "18.9.20.1.8"
     Task = "(L2) Ensure 'Turn off Registration if URL connection is referring to Microsoft.com' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Registration Wizard Control" `
                 -Name "NoRegistration" `
-                | Select-Object -ExpandProperty "NoRegistration"
+            | Select-Object -ExpandProperty "NoRegistration"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.9"
+    Id   = "18.9.20.1.9"
     Task = "(L2) Ensure 'Turn off Search Companion content file updates' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\SearchCompanion" `
                 -Name "DisableContentFileUpdates" `
-                | Select-Object -ExpandProperty "DisableContentFileUpdates"
+            | Select-Object -ExpandProperty "DisableContentFileUpdates"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.10"
+    Id   = "18.9.20.1.10"
     Task = "(L2) Ensure 'Turn off the `"Order Prints`" picture task' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoOnlinePrintsWizard" `
-                | Select-Object -ExpandProperty "NoOnlinePrintsWizard"
+            | Select-Object -ExpandProperty "NoOnlinePrintsWizard"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.11"
+    Id   = "18.9.20.1.11"
     Task = "(L2) Ensure 'Turn off the `"Publish to Web`" task for files and folders' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoPublishingWizard" `
-                | Select-Object -ExpandProperty "NoPublishingWizard"
+            | Select-Object -ExpandProperty "NoPublishingWizard"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.12"
+    Id   = "18.9.20.1.12"
     Task = "(L2) Ensure 'Turn off the Windows Messenger Customer Experience Improvement Program' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Messenger\Client" `
                 -Name "CEIP" `
-                | Select-Object -ExpandProperty "CEIP"
+            | Select-Object -ExpandProperty "CEIP"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.13"
+    Id   = "18.9.20.1.13"
     Task = "(L2) Ensure 'Turn off Windows Customer Experience Improvement Program' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\SQMClient\Windows" `
                 -Name "CEIPEnable" `
-                | Select-Object -ExpandProperty "CEIPEnable"
+            | Select-Object -ExpandProperty "CEIPEnable"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.14 A"
+    Id   = "18.9.20.1.14 A"
     Task = "(L2) Ensure 'Turn off Windows Error Reporting' is set to 'Enabled' (Disabled)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Windows Error Reporting" `
                 -Name "Disabled" `
-                | Select-Object -ExpandProperty "Disabled"
+            | Select-Object -ExpandProperty "Disabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.20.1.14 B"
+    Id   = "18.9.20.1.14 B"
     Task = "(L2) Ensure 'Turn off Windows Error Reporting' is set to 'Enabled' (DoReport)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\PCHealth\ErrorReporting" `
                 -Name "DoReport" `
-                | Select-Object -ExpandProperty "DoReport"
+            | Select-Object -ExpandProperty "DoReport"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.23.1 A"
+    Id   = "18.9.23.1 A"
     Task = "(L2) Ensure 'Support device authentication using certificate' is set to 'Enabled: Automatic' (DevicePKInitBehavior)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\kerberos\parameters" `
                 -Name "DevicePKInitBehavior" `
-                | Select-Object -ExpandProperty "DevicePKInitBehavior"
+            | Select-Object -ExpandProperty "DevicePKInitBehavior"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.23.1 B"
+    Id   = "18.9.23.1 B"
     Task = "(L2) Ensure 'Support device authentication using certificate' is set to 'Enabled: Automatic' (DevicePKInitEnabled)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\kerberos\parameters" `
                 -Name "DevicePKInitEnabled" `
-                | Select-Object -ExpandProperty "DevicePKInitEnabled"
+            | Select-Object -ExpandProperty "DevicePKInitEnabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.24.1"
+    Id   = "18.9.24.1"
     Task = "(BL) Ensure 'Enumeration policy for external devices incompatible with Kernel DMA Protection' is set to 'Enabled: Block All'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Kernel DMA Protection" `
                 -Name "DeviceEnumerationPolicy" `
-                | Select-Object -ExpandProperty "DeviceEnumerationPolicy"
+            | Select-Object -ExpandProperty "DeviceEnumerationPolicy"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.25.1"
+    Id   = "18.9.25.1"
     Task = "(L1) Ensure 'Configures LSASS to run as a protected process' is set to 'Enabled: Enabled with UEFI Lock'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "ConfigureLsaProtectedProcess" `
-                | Select-Object -ExpandProperty "ConfigureLsaProtectedProcess"
+            | Select-Object -ExpandProperty "ConfigureLsaProtectedProcess"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.26.1"
+    Id   = "18.9.26.1"
     Task = "(L2) Ensure 'Disallow copying of user input methods to the system account for sign-in' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Control Panel\International" `
                 -Name "BlockUserInputMethodsForSignIn" `
-                | Select-Object -ExpandProperty "BlockUserInputMethodsForSignIn"
+            | Select-Object -ExpandProperty "BlockUserInputMethodsForSignIn"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.27.1"
+    Id   = "18.9.27.1"
     Task = "(L1) Ensure 'Block user from showing account details on sign-in' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "BlockUserFromShowingAccountDetailsOnSignin" `
-                | Select-Object -ExpandProperty "BlockUserFromShowingAccountDetailsOnSignin"
+            | Select-Object -ExpandProperty "BlockUserFromShowingAccountDetailsOnSignin"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.27.2"
+    Id   = "18.9.27.2"
     Task = "(L1) Ensure 'Do not display network selection UI' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System" `
                 -Name "DontDisplayNetworkSelectionUI" `
-                | Select-Object -ExpandProperty "DontDisplayNetworkSelectionUI"
+            | Select-Object -ExpandProperty "DontDisplayNetworkSelectionUI"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.27.3"
+    Id   = "18.9.27.3"
     Task = "(L1) Ensure 'Turn off app notifications on the lock screen' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "DisableLockScreenAppNotifications" `
-                | Select-Object -ExpandProperty "DisableLockScreenAppNotifications"
+            | Select-Object -ExpandProperty "DisableLockScreenAppNotifications"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.27.4"
+    Id   = "18.9.27.4"
     Task = "(L1) Ensure 'Turn on convenience PIN sign-in' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "AllowDomainPINLogon" `
-                | Select-Object -ExpandProperty "AllowDomainPINLogon"
+            | Select-Object -ExpandProperty "AllowDomainPINLogon"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.30.1"
+    Id   = "18.9.30.1"
     Task = "(L2) Ensure 'Allow Clipboard synchronization across devices' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "AllowCrossDeviceClipboard" `
-                | Select-Object -ExpandProperty "AllowCrossDeviceClipboard"
+            | Select-Object -ExpandProperty "AllowCrossDeviceClipboard"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.30.2"
+    Id   = "18.9.30.2"
     Task = "(L2) Ensure 'Allow upload of User Activities' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "UploadUserActivities" `
-                | Select-Object -ExpandProperty "UploadUserActivities"
+            | Select-Object -ExpandProperty "UploadUserActivities"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.32.6.1"
+    Id   = "18.9.32.6.1"
     Task = "(L1) Ensure 'Allow network connectivity during connected-standby (on battery)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9" `
                 -Name "DCSettingIndex" `
-                | Select-Object -ExpandProperty "DCSettingIndex"
+            | Select-Object -ExpandProperty "DCSettingIndex"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.32.6.2"
+    Id   = "18.9.32.6.2"
     Task = "(L1) Ensure 'Allow network connectivity during connected-standby (plugged in)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9" `
                 -Name "ACSettingIndex" `
-                | Select-Object -ExpandProperty "ACSettingIndex"
+            | Select-Object -ExpandProperty "ACSettingIndex"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.32.6.3"
+    Id   = "18.9.32.6.3"
     Task = "(BL) Ensure 'Allow standby states (S1-S3) when sleeping (on battery)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\abfc2519-3608-4c2a-94ea-171b0ed546ab" `
                 -Name "DCSettingIndex" `
-                | Select-Object -ExpandProperty "DCSettingIndex"
+            | Select-Object -ExpandProperty "DCSettingIndex"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.32.6.4"
+    Id   = "18.9.32.6.4"
     Task = "(BL) Ensure 'Allow standby states (S1-S3) when sleeping (plugged in)' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\abfc2519-3608-4c2a-94ea-171b0ed546ab" `
                 -Name "ACSettingIndex" `
-                | Select-Object -ExpandProperty "ACSettingIndex"
+            | Select-Object -ExpandProperty "ACSettingIndex"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.32.6.5"
+    Id   = "18.9.32.6.5"
     Task = "(L1) Ensure 'Require a password when a computer wakes (on battery)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51" `
                 -Name "DCSettingIndex" `
-                | Select-Object -ExpandProperty "DCSettingIndex"
+            | Select-Object -ExpandProperty "DCSettingIndex"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.32.6.6"
+    Id   = "18.9.32.6.6"
     Task = "(L1) Ensure 'Require a password when a computer wakes (plugged in)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51" `
                 -Name "ACSettingIndex" `
-                | Select-Object -ExpandProperty "ACSettingIndex"
+            | Select-Object -ExpandProperty "ACSettingIndex"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.34.1"
+    Id   = "18.9.34.1"
     Task = "(L1) Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fAllowUnsolicited" `
-                | Select-Object -ExpandProperty "fAllowUnsolicited"
+            | Select-Object -ExpandProperty "fAllowUnsolicited"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.34.2"
+    Id   = "18.9.34.2"
     Task = "(L1) Ensure 'Configure Solicited Remote Assistance' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fAllowToGetHelp" `
-                | Select-Object -ExpandProperty "fAllowToGetHelp"
+            | Select-Object -ExpandProperty "fAllowToGetHelp"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.35.1"
+    Id   = "18.9.35.1"
     Task = "(L1) Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Rpc" `
                 -Name "EnableAuthEpResolution" `
-                | Select-Object -ExpandProperty "EnableAuthEpResolution"
+            | Select-Object -ExpandProperty "EnableAuthEpResolution"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.35.2"
+    Id   = "18.9.35.2"
     Task = "(L1) Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled: Authenticated'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Rpc" `
                 -Name "RestrictRemoteClients" `
-                | Select-Object -ExpandProperty "RestrictRemoteClients"
+            | Select-Object -ExpandProperty "RestrictRemoteClients"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.46.5.1"
+    Id   = "18.9.46.5.1"
     Task = "(L2) Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interactive communication with support provider' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\ScriptedDiagnosticsProvider\Policy" `
                 -Name "DisableQueryRemoteServer" `
-                | Select-Object -ExpandProperty "DisableQueryRemoteServer"
+            | Select-Object -ExpandProperty "DisableQueryRemoteServer"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.46.11.1"
+    Id   = "18.9.46.11.1"
     Task = "(L2) Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WDI\{9c5a40da-b965-4fc3-8781-88dd50a6299d}" `
                 -Name "ScenarioExecutionEnabled" `
-                | Select-Object -ExpandProperty "ScenarioExecutionEnabled"
+            | Select-Object -ExpandProperty "ScenarioExecutionEnabled"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.9.48.1"
+    Id   = "18.9.48.1"
     Task = "(L2) Ensure 'Turn off the advertising ID' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AdvertisingInfo" `
                 -Name "DisabledByGroupPolicy" `
-                | Select-Object -ExpandProperty "DisabledByGroupPolicy"
+            | Select-Object -ExpandProperty "DisabledByGroupPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.3.1"
+    Id   = "18.10.3.1"
     Task = "(L2) Ensure 'Allow a Windows app to share application data between users' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\AppModel\StateManager" `
                 -Name "AllowSharedLocalAppData" `
-                | Select-Object -ExpandProperty "AllowSharedLocalAppData"
+            | Select-Object -ExpandProperty "AllowSharedLocalAppData"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.3.2"
+    Id   = "18.10.3.2"
     Task = "(L1) Ensure 'Prevent non-admin users from installing packaged Windows apps' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Appx" `
                 -Name "BlockNonAdminUserInstall" `
-                | Select-Object -ExpandProperty "BlockNonAdminUserInstall"
+            | Select-Object -ExpandProperty "BlockNonAdminUserInstall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.4.1"
+    Id   = "18.10.4.1"
     Task = "(L1) Ensure 'Let Windows apps activate with voice while the system is locked' is set to 'Enabled: Force Deny'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppPrivacy" `
                 -Name "LetAppsActivateWithVoiceAboveLock" `
-                | Select-Object -ExpandProperty "LetAppsActivateWithVoiceAboveLock"
+            | Select-Object -ExpandProperty "LetAppsActivateWithVoiceAboveLock"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.5.1"
+    Id   = "18.10.5.1"
     Task = "(L1) Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "MSAOptional" `
-                | Select-Object -ExpandProperty "MSAOptional"
+            | Select-Object -ExpandProperty "MSAOptional"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.5.2"
+    Id   = "18.10.5.2"
     Task = "(L2) Ensure 'Block launching Universal Windows apps with Windows Runtime API access from hosted content.' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "BlockHostedAppAccessWinRT" `
-                | Select-Object -ExpandProperty "BlockHostedAppAccessWinRT"
+            | Select-Object -ExpandProperty "BlockHostedAppAccessWinRT"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.7.1"
+    Id   = "18.10.7.1"
     Task = "(L1) Ensure 'Disallow Autoplay for non-volume devices' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer" `
                 -Name "NoAutoplayfornonVolume" `
-                | Select-Object -ExpandProperty "NoAutoplayfornonVolume"
+            | Select-Object -ExpandProperty "NoAutoplayfornonVolume"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.7.2"
+    Id   = "18.10.7.2"
     Task = "(L1) Ensure 'Set the default behavior for AutoRun' is set to 'Enabled: Do not execute any autorun commands'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoAutorun" `
-                | Select-Object -ExpandProperty "NoAutorun"
+            | Select-Object -ExpandProperty "NoAutorun"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.7.3"
+    Id   = "18.10.7.3"
     Task = "(L1) Ensure 'Turn off Autoplay' is set to 'Enabled: All drives'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoDriveTypeAutoRun" `
-                | Select-Object -ExpandProperty "NoDriveTypeAutoRun"
+            | Select-Object -ExpandProperty "NoDriveTypeAutoRun"
         
             if ($regValue -ne 255) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 255"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.8.1.1"
+    Id   = "18.10.8.1.1"
     Task = "(L1) Ensure 'Configure enhanced anti-spoofing' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Biometrics\FacialFeatures" `
                 -Name "EnhancedAntiSpoofing" `
-                | Select-Object -ExpandProperty "EnhancedAntiSpoofing"
+            | Select-Object -ExpandProperty "EnhancedAntiSpoofing"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.1"
+    Id   = "18.10.9.1.1"
     Task = "(BL) Ensure 'Allow access to BitLocker-protected fixed data drives from earlier versions of Windows' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "FDVDiscoveryVolumeType" `
-                | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
+            | Select-Object -ExpandProperty "FDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: This value should be empty."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.2"
+    Id   = "18.10.9.1.2"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVRecovery" `
-                | Select-Object -ExpandProperty "FDVRecovery"
+            | Select-Object -ExpandProperty "FDVRecovery"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.3"
+    Id   = "18.10.9.1.3"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Allow data recovery agent' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVManageDRA" `
-                | Select-Object -ExpandProperty "FDVManageDRA"
+            | Select-Object -ExpandProperty "FDVManageDRA"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.4"
+    Id   = "18.10.9.1.4"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Recovery Password' is set to 'Enabled: Allow 48-digit recovery password'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVRecoveryPassword" `
-                | Select-Object -ExpandProperty "FDVRecoveryPassword"
+            | Select-Object -ExpandProperty "FDVRecoveryPassword"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.5"
+    Id   = "18.10.9.1.5"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Recovery Key' is set to 'Enabled: Allow 256-bit recovery key'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVRecoveryKey" `
-                | Select-Object -ExpandProperty "FDVRecoveryKey"
+            | Select-Object -ExpandProperty "FDVRecoveryKey"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.6"
+    Id   = "18.10.9.1.6"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Omit recovery options from the BitLocker setup wizard' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVHideRecoveryPage" `
-                | Select-Object -ExpandProperty "FDVHideRecoveryPage"
+            | Select-Object -ExpandProperty "FDVHideRecoveryPage"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.7"
+    Id   = "18.10.9.1.7"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Save BitLocker recovery information to AD DS for fixed data drives' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVActiveDirectoryBackup" `
-                | Select-Object -ExpandProperty "FDVActiveDirectoryBackup"
+            | Select-Object -ExpandProperty "FDVActiveDirectoryBackup"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.8"
+    Id   = "18.10.9.1.8"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Configure storage of BitLocker recovery information to AD DS' is set to 'Enabled: Backup recovery passwords and key packages'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVActiveDirectoryInfoToStore" `
-                | Select-Object -ExpandProperty "FDVActiveDirectoryInfoToStore"
+            | Select-Object -ExpandProperty "FDVActiveDirectoryInfoToStore"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.9"
+    Id   = "18.10.9.1.9"
     Task = "(BL) Ensure 'Choose how BitLocker-protected fixed drives can be recovered: Do not enable BitLocker until recovery information is stored to AD DS for fixed data drives' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVRequireActiveDirectoryBackup" `
-                | Select-Object -ExpandProperty "FDVRequireActiveDirectoryBackup"
+            | Select-Object -ExpandProperty "FDVRequireActiveDirectoryBackup"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.10"
+    Id   = "18.10.9.1.10"
     Task = "(BL) Ensure 'Configure use of hardware-based encryption for fixed data drives' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "FDVHardwareEncryption" `
-                | Select-Object -ExpandProperty "FDVHardwareEncryption"
+            | Select-Object -ExpandProperty "FDVHardwareEncryption"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.11"
+    Id   = "18.10.9.1.11"
     Task = "(BL) Ensure 'Configure use of passwords for fixed data drives' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "FDVPassphrase" `
-                | Select-Object -ExpandProperty "FDVPassphrase"
+            | Select-Object -ExpandProperty "FDVPassphrase"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.12"
+    Id   = "18.10.9.1.12"
     Task = "(BL) Ensure 'Configure use of smart cards on fixed data drives' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "FDVAllowUserCert" `
-                | Select-Object -ExpandProperty "FDVAllowUserCert"
+            | Select-Object -ExpandProperty "FDVAllowUserCert"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.1.13"
+    Id   = "18.10.9.1.13"
     Task = "(BL) Ensure 'Configure use of smart cards on fixed data drives: Require use of smart cards on fixed data drives' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "FDVEnforceUserCert" `
-                | Select-Object -ExpandProperty "FDVEnforceUserCert"
+            | Select-Object -ExpandProperty "FDVEnforceUserCert"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.1"
+    Id   = "18.10.9.2.1"
     Task = "(BL) Ensure 'Allow enhanced PINs for startup' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "UseEnhancedPin" `
-                | Select-Object -ExpandProperty "UseEnhancedPin"
+            | Select-Object -ExpandProperty "UseEnhancedPin"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.2"
+    Id   = "18.10.9.2.2"
     Task = "(BL) Ensure 'Allow Secure Boot for integrity validation' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "OSAllowSecureBootForIntegrity" `
-                | Select-Object -ExpandProperty "OSAllowSecureBootForIntegrity"
+            | Select-Object -ExpandProperty "OSAllowSecureBootForIntegrity"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.3"
+    Id   = "18.10.9.2.3"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSRecovery" `
-                | Select-Object -ExpandProperty "OSRecovery"
+            | Select-Object -ExpandProperty "OSRecovery"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.4"
+    Id   = "18.10.9.2.4"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Allow data recovery agent' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSManageDRA" `
-                | Select-Object -ExpandProperty "OSManageDRA"
+            | Select-Object -ExpandProperty "OSManageDRA"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.5"
+    Id   = "18.10.9.2.5"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Recovery Password' is set to 'Enabled: Require 48-digit recovery password'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSRecoveryPassword" `
-                | Select-Object -ExpandProperty "OSRecoveryPassword"
+            | Select-Object -ExpandProperty "OSRecoveryPassword"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.6"
+    Id   = "18.10.9.2.6"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Recovery Key' is set to 'Enabled: Do not allow 256-bit recovery key'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSRecoveryKey" `
-                | Select-Object -ExpandProperty "OSRecoveryKey"
+            | Select-Object -ExpandProperty "OSRecoveryKey"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.7"
+    Id   = "18.10.9.2.7"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Omit recovery options from the BitLocker setup wizard' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSHideRecoveryPage" `
-                | Select-Object -ExpandProperty "OSHideRecoveryPage"
+            | Select-Object -ExpandProperty "OSHideRecoveryPage"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.8"
+    Id   = "18.10.9.2.8"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Save BitLocker recovery information to AD DS for operating system drives' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSActiveDirectoryBackup" `
-                | Select-Object -ExpandProperty "OSActiveDirectoryBackup"
+            | Select-Object -ExpandProperty "OSActiveDirectoryBackup"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.9"
+    Id   = "18.10.9.2.9"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Configure storage of BitLocker recovery information to AD DS:' is set to 'Enabled: Store recovery passwords and key packages'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSActiveDirectoryInfoToStore" `
-                | Select-Object -ExpandProperty "OSActiveDirectoryInfoToStore"
+            | Select-Object -ExpandProperty "OSActiveDirectoryInfoToStore"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.10"
+    Id   = "18.10.9.2.10"
     Task = "(BL) Ensure 'Choose how BitLocker-protected operating system drives can be recovered: Do not enable BitLocker until recovery information is stored to AD DS for operating system drives' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSRequireActiveDirectoryBackup" `
-                | Select-Object -ExpandProperty "OSRequireActiveDirectoryBackup"
+            | Select-Object -ExpandProperty "OSRequireActiveDirectoryBackup"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.11"
+    Id   = "18.10.9.2.11"
     Task = "(BL) Ensure 'Configure use of hardware-based encryption for operating system drives' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "OSHardwareEncryption" `
-                | Select-Object -ExpandProperty "OSHardwareEncryption"
+            | Select-Object -ExpandProperty "OSHardwareEncryption"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.12"
+    Id   = "18.10.9.2.12"
     Task = "(BL) Ensure 'Configure use of passwords for operating system drives' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "OSPassphrase" `
-                | Select-Object -ExpandProperty "OSPassphrase"
+            | Select-Object -ExpandProperty "OSPassphrase"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.13"
+    Id   = "18.10.9.2.13"
     Task = "(BL) Ensure 'Require additional authentication at startup' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "UseAdvancedStartup" `
-                | Select-Object -ExpandProperty "UseAdvancedStartup"
+            | Select-Object -ExpandProperty "UseAdvancedStartup"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.14"
+    Id   = "18.10.9.2.14"
     Task = "(BL) Ensure 'Require additional authentication at startup: Allow BitLocker without a compatible TPM' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "EnableBDEWithNoTPM" `
-                | Select-Object -ExpandProperty "EnableBDEWithNoTPM"
+            | Select-Object -ExpandProperty "EnableBDEWithNoTPM"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.15"
+    Id   = "18.10.9.2.15"
     Task = "(BL) Ensure 'Require additional authentication at startup: Configure TPM startup:' is set to 'Enabled: Do not allow TPM'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "UseTPM" `
-                | Select-Object -ExpandProperty "UseTPM"
+            | Select-Object -ExpandProperty "UseTPM"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.16"
+    Id   = "18.10.9.2.16"
     Task = "(BL) Ensure 'Require additional authentication at startup: Configure TPM startup PIN:' is set to 'Enabled: Require startup PIN with TPM'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "UseTPMPIN" `
-                | Select-Object -ExpandProperty "UseTPMPIN"
+            | Select-Object -ExpandProperty "UseTPMPIN"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.17"
+    Id   = "18.10.9.2.17"
     Task = "(BL) Ensure 'Require additional authentication at startup: Configure TPM startup key:' is set to 'Enabled: Do not allow startup key with TPM'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "UseTPMKey" `
-                | Select-Object -ExpandProperty "UseTPMKey"
+            | Select-Object -ExpandProperty "UseTPMKey"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.2.18"
+    Id   = "18.10.9.2.18"
     Task = "(BL) Ensure 'Require additional authentication at startup: Configure TPM startup key and PIN:' is set to 'Enabled: Do not allow startup key and PIN with TPM'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "UseTPMKeyPIN" `
-                | Select-Object -ExpandProperty "UseTPMKeyPIN"
+            | Select-Object -ExpandProperty "UseTPMKeyPIN"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.1"
+    Id   = "18.10.9.3.1"
     Task = "(BL) Ensure 'Allow access to BitLocker-protected removable data drives from earlier versions of Windows' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "RDVDiscoveryVolumeType" `
-                | Select-Object -ExpandProperty "RDVDiscoveryVolumeType"
+            | Select-Object -ExpandProperty "RDVDiscoveryVolumeType"
         
             if ($regValue -ne "") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: ''"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.2"
+    Id   = "18.10.9.3.2"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVRecovery" `
-                | Select-Object -ExpandProperty "RDVRecovery"
+            | Select-Object -ExpandProperty "RDVRecovery"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.3"
+    Id   = "18.10.9.3.3"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Allow data recovery agent' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVManageDRA" `
-                | Select-Object -ExpandProperty "RDVManageDRA"
+            | Select-Object -ExpandProperty "RDVManageDRA"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.4"
+    Id   = "18.10.9.3.4"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Recovery Password' is set to 'Enabled: Do not allow 48-digit recovery password'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVRecoveryPassword" `
-                | Select-Object -ExpandProperty "RDVRecoveryPassword"
+            | Select-Object -ExpandProperty "RDVRecoveryPassword"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.5"
+    Id   = "18.10.9.3.5"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Recovery Key' is set to 'Enabled: Do not allow 256-bit recovery key'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVRecoveryKey" `
-                | Select-Object -ExpandProperty "RDVRecoveryKey"
+            | Select-Object -ExpandProperty "RDVRecoveryKey"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.6"
+    Id   = "18.10.9.3.6"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Omit recovery options from the BitLocker setup wizard' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVHideRecoveryPage" `
-                | Select-Object -ExpandProperty "RDVHideRecoveryPage"
+            | Select-Object -ExpandProperty "RDVHideRecoveryPage"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.7"
+    Id   = "18.10.9.3.7"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Save BitLocker recovery information to AD DS for removable data drives' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVActiveDirectoryBackup" `
-                | Select-Object -ExpandProperty "RDVActiveDirectoryBackup"
+            | Select-Object -ExpandProperty "RDVActiveDirectoryBackup"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.8"
+    Id   = "18.10.9.3.8"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Configure storage of BitLocker recovery information to AD DS:' is set to 'Enabled: Backup recovery passwords and key packages'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVActiveDirectoryInfoToStore" `
-                | Select-Object -ExpandProperty "RDVActiveDirectoryInfoToStore"
+            | Select-Object -ExpandProperty "RDVActiveDirectoryInfoToStore"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.9"
+    Id   = "18.10.9.3.9"
     Task = "(BL) Ensure 'Choose how BitLocker-protected removable drives can be recovered: Do not enable BitLocker until recovery information is stored to AD DS for removable data drives' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVRequireActiveDirectoryBackup" `
-                | Select-Object -ExpandProperty "RDVRequireActiveDirectoryBackup"
+            | Select-Object -ExpandProperty "RDVRequireActiveDirectoryBackup"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.10"
+    Id   = "18.10.9.3.10"
     Task = "(BL) Ensure 'Configure use of hardware-based encryption for removable data drives' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVHardwareEncryption" `
-                | Select-Object -ExpandProperty "RDVHardwareEncryption"
+            | Select-Object -ExpandProperty "RDVHardwareEncryption"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.11"
+    Id   = "18.10.9.3.11"
     Task = "(BL) Ensure 'Configure use of passwords for removable data drives' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "RDVPassphrase" `
-                | Select-Object -ExpandProperty "RDVPassphrase"
+            | Select-Object -ExpandProperty "RDVPassphrase"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.12"
+    Id   = "18.10.9.3.12"
     Task = "(BL) Ensure 'Configure use of smart cards on removable data drives' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "RDVAllowUserCert" `
-                | Select-Object -ExpandProperty "RDVAllowUserCert"
+            | Select-Object -ExpandProperty "RDVAllowUserCert"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.13"
+    Id   = "18.10.9.3.13"
     Task = "(BL) Ensure 'Configure use of smart cards on removable data drives: Require use of smart cards on removable data drives' is set to 'Enabled: True'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "RDVEnforceUserCert" `
-                | Select-Object -ExpandProperty "RDVEnforceUserCert"
+            | Select-Object -ExpandProperty "RDVEnforceUserCert"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.14"
+    Id   = "18.10.9.3.14"
     Task = "(BL) Ensure 'Deny write access to removable drives not protected by BitLocker' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Policies\Microsoft\FVE" `
                 -Name "RDVDenyWriteAccess" `
-                | Select-Object -ExpandProperty "RDVDenyWriteAccess"
+            | Select-Object -ExpandProperty "RDVDenyWriteAccess"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.3.15"
+    Id   = "18.10.9.3.15"
     Task = "(BL) Ensure 'Deny write access to removable drives not protected by BitLocker: Do not allow write access to devices configured in another organization' is set to 'Enabled: False'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\FVE" `
                 -Name "RDVDenyCrossOrg" `
-                | Select-Object -ExpandProperty "RDVDenyCrossOrg"
+            | Select-Object -ExpandProperty "RDVDenyCrossOrg"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.9.4"
+    Id   = "18.10.9.4"
     Task = "(BL) Ensure 'Disable new DMA devices when this computer is locked' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "DisableExternalDMAUnderLock" `
-                | Select-Object -ExpandProperty "DisableExternalDMAUnderLock"
+            | Select-Object -ExpandProperty "DisableExternalDMAUnderLock"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.10.1"
+    Id   = "18.10.10.1"
     Task = "(L2) Ensure 'Allow Use of Camera' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Camera" `
                 -Name "AllowCamera" `
-                | Select-Object -ExpandProperty "AllowCamera"
+            | Select-Object -ExpandProperty "AllowCamera"
         
             if ($regValue -eq 0) {
                 return @{
                     Message = "Compliant"
-                    Status = "True"
+                    Status  = "True"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
 
@@ -10394,1431 +10394,1431 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam" `
                 -Name "Value" `
-                | Select-Object -ExpandProperty "Value"
+            | Select-Object -ExpandProperty "Value"
         
             if ($regValue -match "Deny") {
                 return @{
                     Message = "Compliant"
-                    Status = "True"
+                    Status  = "True"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Camera is not deactivated."
-            Status = "False"
+            Status  = "False"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.12.1"
+    Id   = "18.10.12.1"
     Task = "(L1) Ensure 'Turn off cloud consumer account state content' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableConsumerAccountStateContent" `
-                | Select-Object -ExpandProperty "DisableConsumerAccountStateContent"
+            | Select-Object -ExpandProperty "DisableConsumerAccountStateContent"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.12.2"
+    Id   = "18.10.12.2"
     Task = "(L2) Ensure 'Turn off cloud optimized content' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableCloudOptimizedContent" `
-                | Select-Object -ExpandProperty "DisableCloudOptimizedContent"
+            | Select-Object -ExpandProperty "DisableCloudOptimizedContent"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.12.3"
+    Id   = "18.10.12.3"
     Task = "(L1) Ensure 'Turn off Microsoft consumer experiences' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableWindowsConsumerFeatures" `
-                | Select-Object -ExpandProperty "DisableWindowsConsumerFeatures"
+            | Select-Object -ExpandProperty "DisableWindowsConsumerFeatures"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.13.1"
+    Id   = "18.10.13.1"
     Task = "(L1) Ensure 'Require pin for pairing' is set to 'Enabled: First Time' OR 'Enabled: Always'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Connect" `
                 -Name "RequirePinForPairing" `
-                | Select-Object -ExpandProperty "RequirePinForPairing"
+            | Select-Object -ExpandProperty "RequirePinForPairing"
         
             if (($regValue -ne 1) -and ($regValue -ne 2)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 1 or x == 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.14.1"
+    Id   = "18.10.14.1"
     Task = "(L1) Ensure 'Do not display the password reveal button' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CredUI" `
                 -Name "DisablePasswordReveal" `
-                | Select-Object -ExpandProperty "DisablePasswordReveal"
+            | Select-Object -ExpandProperty "DisablePasswordReveal"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.14.2"
+    Id   = "18.10.14.2"
     Task = "(L1) Ensure 'Enumerate administrator accounts on elevation' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\CredUI" `
                 -Name "EnumerateAdministrators" `
-                | Select-Object -ExpandProperty "EnumerateAdministrators"
+            | Select-Object -ExpandProperty "EnumerateAdministrators"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.14.3"
+    Id   = "18.10.14.3"
     Task = "(L1) Ensure 'Prevent the use of security questions for local accounts' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "NoLocalPasswordResetQuestions" `
-                | Select-Object -ExpandProperty "NoLocalPasswordResetQuestions"
+            | Select-Object -ExpandProperty "NoLocalPasswordResetQuestions"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.1"
+    Id   = "18.10.15.1"
     Task = "(L1) Ensure 'Allow Diagnostic Data' is set to '0 - Enabled: Diagnostic data off (not recommended)' or '1 - Enabled: Send required diagnostic data'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DataCollection" `
                 -Name "AllowTelemetry" `
-                | Select-Object -ExpandProperty "AllowTelemetry"
+            | Select-Object -ExpandProperty "AllowTelemetry"
         
             if (($regValue -ne 0) -and ($regValue -ne 1)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 0 or x == 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.2"
+    Id   = "18.10.15.2"
     Task = "(L2) Ensure 'Configure Authenticated Proxy usage for the Connected User Experience and Telemetry service' is set to 'Enabled: Disable Authenticated Proxy usage'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection" `
                 -Name "DisableEnterpriseAuthProxy" `
-                | Select-Object -ExpandProperty "DisableEnterpriseAuthProxy"
+            | Select-Object -ExpandProperty "DisableEnterpriseAuthProxy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.3"
+    Id   = "18.10.15.3"
     Task = "(L1) Ensure 'Disable OneSettings Downloads' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection" `
                 -Name "DisableOneSettingsDownloads" `
-                | Select-Object -ExpandProperty "DisableOneSettingsDownloads"
+            | Select-Object -ExpandProperty "DisableOneSettingsDownloads"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.4"
+    Id   = "18.10.15.4"
     Task = "(L1) Ensure 'Do not show feedback notifications' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection" `
                 -Name "DoNotShowFeedbackNotifications" `
-                | Select-Object -ExpandProperty "DoNotShowFeedbackNotifications"
+            | Select-Object -ExpandProperty "DoNotShowFeedbackNotifications"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.5"
+    Id   = "18.10.15.5"
     Task = "(L1) Ensure 'Enable OneSettings Auditing' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection" `
                 -Name "EnableOneSettingsAuditing" `
-                | Select-Object -ExpandProperty "EnableOneSettingsAuditing"
+            | Select-Object -ExpandProperty "EnableOneSettingsAuditing"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.6"
+    Id   = "18.10.15.6"
     Task = "(L1) Ensure 'Limit Diagnostic Log Collection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection" `
                 -Name "LimitDiagnosticLogCollection" `
-                | Select-Object -ExpandProperty "LimitDiagnosticLogCollection"
+            | Select-Object -ExpandProperty "LimitDiagnosticLogCollection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.7"
+    Id   = "18.10.15.7"
     Task = "(L1) Ensure 'Limit Dump Collection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DataCollection" `
                 -Name "LimitDumpCollection" `
-                | Select-Object -ExpandProperty "LimitDumpCollection"
+            | Select-Object -ExpandProperty "LimitDumpCollection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.15.8"
+    Id   = "18.10.15.8"
     Task = "(L1) Ensure 'Toggle user control over Insider builds' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PreviewBuilds" `
                 -Name "AllowBuildPreview" `
-                | Select-Object -ExpandProperty "AllowBuildPreview"
+            | Select-Object -ExpandProperty "AllowBuildPreview"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.16.1"
+    Id   = "18.10.16.1"
     Task = "(L1) Ensure 'Download Mode' is NOT set to 'Enabled: Internet'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeliveryOptimization" `
                 -Name "DODownloadMode" `
-                | Select-Object -ExpandProperty "DODownloadMode"
+            | Select-Object -ExpandProperty "DODownloadMode"
         
             if (($regValue -eq 3)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x != 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.17.1"
+    Id   = "18.10.17.1"
     Task = "(L1) Ensure 'Enable App Installer' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller" `
                 -Name "EnableAppInstaller" `
-                | Select-Object -ExpandProperty "EnableAppInstaller"
+            | Select-Object -ExpandProperty "EnableAppInstaller"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.17.2"
+    Id   = "18.10.17.2"
     Task = "(L1) Ensure 'Enable App Installer Experimental Features' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller" `
                 -Name "EnableExperimentalFeatures" `
-                | Select-Object -ExpandProperty "EnableExperimentalFeatures"
+            | Select-Object -ExpandProperty "EnableExperimentalFeatures"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.17.3"
+    Id   = "18.10.17.3"
     Task = "(L1) Ensure 'Enable App Installer Hash Override' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller" `
                 -Name "EnableHashOverride" `
-                | Select-Object -ExpandProperty "EnableHashOverride"
+            | Select-Object -ExpandProperty "EnableHashOverride"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.17.4"
+    Id   = "18.10.17.4"
     Task = "(L1) Ensure 'Enable App Installer ms-appinstaller protocol' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\AppInstaller" `
                 -Name "EnableMSAppInstallerProtocol" `
-                | Select-Object -ExpandProperty "EnableMSAppInstallerProtocol"
+            | Select-Object -ExpandProperty "EnableMSAppInstallerProtocol"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.1.1"
+    Id   = "18.10.26.1.1"
     Task = "(L1) Ensure 'Application: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application" `
                 -Name "Retention" `
-                | Select-Object -ExpandProperty "Retention"
+            | Select-Object -ExpandProperty "Retention"
         
             if ($regValue -ne "0") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.1.2"
+    Id   = "18.10.26.1.2"
     Task = "(L1) Ensure 'Application: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if (($regValue -lt 32768)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 32768"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.2.1"
+    Id   = "18.10.26.2.1"
     Task = "(L1) Ensure 'Security: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security" `
                 -Name "Retention" `
-                | Select-Object -ExpandProperty "Retention"
+            | Select-Object -ExpandProperty "Retention"
         
             if ($regValue -ne "0") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.2.2"
+    Id   = "18.10.26.2.2"
     Task = "(L1) Ensure 'Security: Specify the maximum log file size (KB)' is set to 'Enabled: 196,608 or greater'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if (($regValue -lt 196608)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 196608"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.3.1"
+    Id   = "18.10.26.3.1"
     Task = "(L1) Ensure 'Setup: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup" `
                 -Name "Retention" `
-                | Select-Object -ExpandProperty "Retention"
+            | Select-Object -ExpandProperty "Retention"
         
             if ($regValue -ne "0") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.3.2"
+    Id   = "18.10.26.3.2"
     Task = "(L1) Ensure 'Setup: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Setup" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if (($regValue -lt 32768)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 32768"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.4.1"
+    Id   = "18.10.26.4.1"
     Task = "(L1) Ensure 'System: Control Event Log behavior when the log file reaches its maximum size' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System" `
                 -Name "Retention" `
-                | Select-Object -ExpandProperty "Retention"
+            | Select-Object -ExpandProperty "Retention"
         
             if ($regValue -ne "0") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.26.4.2"
+    Id   = "18.10.26.4.2"
     Task = "(L1) Ensure 'System: Specify the maximum log file size (KB)' is set to 'Enabled: 32,768 or greater'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if (($regValue -lt 32768)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 32768"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.29.2"
+    Id   = "18.10.29.2"
     Task = "(L1) Ensure 'Turn off Data Execution Prevention for Explorer' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer" `
                 -Name "NoDataExecutionPrevention" `
-                | Select-Object -ExpandProperty "NoDataExecutionPrevention"
+            | Select-Object -ExpandProperty "NoDataExecutionPrevention"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.29.3"
+    Id   = "18.10.29.3"
     Task = "(L1) Ensure 'Turn off heap termination on corruption' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer" `
                 -Name "NoHeapTerminationOnCorruption" `
-                | Select-Object -ExpandProperty "NoHeapTerminationOnCorruption"
+            | Select-Object -ExpandProperty "NoHeapTerminationOnCorruption"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.29.4"
+    Id   = "18.10.29.4"
     Task = "(L1) Ensure 'Turn off shell protocol protected mode' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "PreXPSP2ShellProtocolBehavior" `
-                | Select-Object -ExpandProperty "PreXPSP2ShellProtocolBehavior"
+            | Select-Object -ExpandProperty "PreXPSP2ShellProtocolBehavior"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.33.1"
+    Id   = "18.10.33.1"
     Task = "(L1) Ensure 'Prevent the computer from joining a homegroup' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\HomeGroup" `
                 -Name "DisableHomeGroup" `
-                | Select-Object -ExpandProperty "DisableHomeGroup"
+            | Select-Object -ExpandProperty "DisableHomeGroup"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.35.1"
+    Id   = "18.10.35.1"
     Task = "(L1) 'Disable Internet Explorer 11 as a standalone browser' is set to 'Enabled: Always'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Internet Explorer\Main" `
                 -Name "NotifyDisableIEOptions" `
-                | Select-Object -ExpandProperty "NotifyDisableIEOptions"
+            | Select-Object -ExpandProperty "NotifyDisableIEOptions"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.37.1"
+    Id   = "18.10.37.1"
     Task = "(L2) Ensure 'Turn off location' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" `
                 -Name "DisableLocation" `
-                | Select-Object -ExpandProperty "DisableLocation"
+            | Select-Object -ExpandProperty "DisableLocation"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.41.1"
+    Id   = "18.10.41.1"
     Task = "(L2) Ensure 'Allow Message Service Cloud Sync' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Messaging" `
                 -Name "AllowMessageSync" `
-                | Select-Object -ExpandProperty "AllowMessageSync"
+            | Select-Object -ExpandProperty "AllowMessageSync"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.42.1"
+    Id   = "18.10.42.1"
     Task = "(L1) Ensure 'Block all consumer Microsoft account user authentication' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MicrosoftAccount" `
                 -Name "DisableUserAuth" `
-                | Select-Object -ExpandProperty "DisableUserAuth"
+            | Select-Object -ExpandProperty "DisableUserAuth"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.5.1"
+    Id   = "18.10.43.5.1"
     Task = "(L1) Ensure 'Configure local setting override for reporting to Microsoft MAPS' is set to 'Disabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Spynet" `
                 -Name "LocalSettingOverrideSpynetReporting" `
-                | Select-Object -ExpandProperty "LocalSettingOverrideSpynetReporting"
+            | Select-Object -ExpandProperty "LocalSettingOverrideSpynetReporting"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.5.2"
+    Id   = "18.10.43.5.2"
     Task = "(L2) Ensure 'Join Microsoft MAPS' is set to 'Disabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Spynet" `
                 -Name "SpynetReporting" `
-                | Select-Object -ExpandProperty "SpynetReporting"
+            | Select-Object -ExpandProperty "SpynetReporting"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.1"
+    Id   = "18.10.43.6.1.1"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }            
@@ -11828,61 +11828,61 @@ $windefrunning = CheckWindefRunning
             $Value = "ExploitGuard_ASR_Rules"
             
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR"
             $Value2 = "ExploitGuard_ASR_Rules"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 A"
+    Id   = "18.10.43.6.1.2 A"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Office communication application from creating child processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -11892,61 +11892,61 @@ $windefrunning = CheckWindefRunning
             $Value = "26190899-1602-49e8-8b27-eb1d0a1ce869"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "26190899-1602-49e8-8b27-eb1d0a1ce869"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 B"
+    Id   = "18.10.43.6.1.2 B"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from creating executable content'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -11956,61 +11956,61 @@ $windefrunning = CheckWindefRunning
             $Value = "3b576869-a4ec-4529-8536-b80a7769e899"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "3b576869-a4ec-4529-8536-b80a7769e899"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 D"
+    Id   = "18.10.43.6.1.2 D"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block execution of potentially obfuscated scripts'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                   
@@ -12020,61 +12020,61 @@ $windefrunning = CheckWindefRunning
             $Value = "5beb7efe-fd9a-4556-801d-275e5ffc04cc" 
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "5beb7efe-fd9a-4556-801d-275e5ffc04cc" 
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 E"
+    Id   = "18.10.43.6.1.2 E"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from injecting code into other processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12084,61 +12084,61 @@ $windefrunning = CheckWindefRunning
             $Value = "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 F"
+    Id   = "18.10.43.6.1.2 F"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Adobe Reader from creating child processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12148,61 +12148,61 @@ $windefrunning = CheckWindefRunning
             $Value = "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 G"
+    Id   = "18.10.43.6.1.2 G"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Win32 API calls from Office macro'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12212,61 +12212,61 @@ $windefrunning = CheckWindefRunning
             $Value = "92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 H"
+    Id   = "18.10.43.6.1.2 H"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block credential stealing from the Windows local security authority subsystem (lsass.exe)'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12276,61 +12276,61 @@ $windefrunning = CheckWindefRunning
             $Value = "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 I"
+    Id   = "18.10.43.6.1.2 I"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block untrusted and unsigned processes that run from USB'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12340,106 +12340,106 @@ $windefrunning = CheckWindefRunning
             $Value = "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 J"
+    Id   = "18.10.43.6.1.2 J"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block executable content from email client and webmail'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550" `
-                | Select-Object -ExpandProperty "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
+            | Select-Object -ExpandProperty "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 K"
+    Id   = "18.10.43.6.1.2 K"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block JavaScript or VBScript from launching downloaded executable content'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12449,61 +12449,61 @@ $windefrunning = CheckWindefRunning
             $Value = "d3e037e1-3eb8-44c8-a917-57927947596d"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "d3e037e1-3eb8-44c8-a917-57927947596d"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 L"
+    Id   = "18.10.43.6.1.2 L"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from creating child processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12513,61 +12513,61 @@ $windefrunning = CheckWindefRunning
             $Value = "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.1.2 M"
+    Id   = "18.10.43.6.1.2 M"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block persistence through WMI event subscription'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }                  
@@ -12577,3710 +12577,3710 @@ $windefrunning = CheckWindefRunning
             $Value = "e6db77e5-3df2-4cf1-b95a-636979351e5b"
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
-            if($asrTest1){
+            if ($asrTest1) {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
-                    | Select-Object -ExpandProperty $Value
+                | Select-Object -ExpandProperty $Value
             }
 
             $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
             $Value2 = "e6db77e5-3df2-4cf1-b95a-636979351e5b"
 
             $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
-            if($asrTest2){
+            if ($asrTest2) {
                 $regValueTwo = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path2 `
                     -Name $Value2 `
-                    | Select-Object -ExpandProperty $Value2
+                | Select-Object -ExpandProperty $Value2
             }
 
             if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.6.3.1"
+    Id   = "18.10.43.6.3.1"
     Task = "(L1) Ensure 'Prevent users and apps from accessing dangerous websites' is set to 'Enabled: Block'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\Network Protection" `
                 -Name "EnableNetworkProtection" `
-                | Select-Object -ExpandProperty "EnableNetworkProtection"
+            | Select-Object -ExpandProperty "EnableNetworkProtection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.7.1"
+    Id   = "18.10.43.7.1"
     Task = "(L2) Ensure 'Enable file hash computation feature' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\MpEngine" `
                 -Name "EnableFileHashComputation" `
-                | Select-Object -ExpandProperty "EnableFileHashComputation"
+            | Select-Object -ExpandProperty "EnableFileHashComputation"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.10.1"
+    Id   = "18.10.43.10.1"
     Task = "(L1) Ensure 'Scan all downloaded files and attachments' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableIOAVProtection" `
-                | Select-Object -ExpandProperty "DisableIOAVProtection"
+            | Select-Object -ExpandProperty "DisableIOAVProtection"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.10.2"
+    Id   = "18.10.43.10.2"
     Task = "(L1) Ensure 'Turn off real-time protection' is set to 'Disabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableRealtimeMonitoring" `
-                | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
+            | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.10.3"
+    Id   = "18.10.43.10.3"
     Task = "(L1) Ensure 'Turn on behavior monitoring' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableBehaviorMonitoring" `
-                | Select-Object -ExpandProperty "DisableBehaviorMonitoring"
+            | Select-Object -ExpandProperty "DisableBehaviorMonitoring"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.10.4"
+    Id   = "18.10.43.10.4"
     Task = "(L1) Ensure 'Turn on script scanning' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableScriptScanning" `
-                | Select-Object -ExpandProperty "DisableScriptScanning"
+            | Select-Object -ExpandProperty "DisableScriptScanning"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.12.1"
+    Id   = "18.10.43.12.1"
     Task = "(L2) Ensure 'Configure Watson events' is set to 'Disabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Reporting" `
                 -Name "DisableGenericReports" `
-                | Select-Object -ExpandProperty "DisableGenericReports"
+            | Select-Object -ExpandProperty "DisableGenericReports"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.13.1"
+    Id   = "18.10.43.13.1"
     Task = "(L1) Ensure 'Scan removable drives' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Scan" `
                 -Name "DisableRemovableDriveScanning" `
-                | Select-Object -ExpandProperty "DisableRemovableDriveScanning"
+            | Select-Object -ExpandProperty "DisableRemovableDriveScanning"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.13.2"
+    Id   = "18.10.43.13.2"
     Task = "(L1) Ensure 'Turn on e-mail scanning' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Scan" `
                 -Name "DisableEmailScanning" `
-                | Select-Object -ExpandProperty "DisableEmailScanning"
+            | Select-Object -ExpandProperty "DisableEmailScanning"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.16"
+    Id   = "18.10.43.16"
     Task = "(L1) Ensure 'Configure detection for potentially unwanted applications' is set to 'Enabled: Block'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender" `
                 -Name "PUAProtection" `
-                | Select-Object -ExpandProperty "PUAProtection"
+            | Select-Object -ExpandProperty "PUAProtection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.43.17"
+    Id   = "18.10.43.17"
     Task = "(L1) Ensure 'Turn off Microsoft Defender AntiVirus' is set to 'Disabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender" `
                 -Name "DisableAntiSpyware" `
-                | Select-Object -ExpandProperty "DisableAntiSpyware"
+            | Select-Object -ExpandProperty "DisableAntiSpyware"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.44.1"
+    Id   = "18.10.44.1"
     Task = "(NG) Ensure 'Allow auditing events in Microsoft Defender Application Guard' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI" `
                 -Name "AuditApplicationGuard" `
-                | Select-Object -ExpandProperty "AuditApplicationGuard"
+            | Select-Object -ExpandProperty "AuditApplicationGuard"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.44.2"
+    Id   = "18.10.44.2"
     Task = "(NG) Ensure 'Allow camera and microphone access in Microsoft Defender Application Guard' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI" `
                 -Name "AllowCameraMicrophoneRedirection" `
-                | Select-Object -ExpandProperty "AllowCameraMicrophoneRedirection"
+            | Select-Object -ExpandProperty "AllowCameraMicrophoneRedirection"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.44.3"
+    Id   = "18.10.44.3"
     Task = "(NG) Ensure 'Allow data persistence for Microsoft Defender Application Guard' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI" `
                 -Name "AllowPersistence" `
-                | Select-Object -ExpandProperty "AllowPersistence"
+            | Select-Object -ExpandProperty "AllowPersistence"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.44.4"
+    Id   = "18.10.44.4"
     Task = "(NG) Ensure 'Allow files to download and save to the host operating system from Microsoft Defender Application Guard' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI" `
                 -Name "SaveFilesToHost" `
-                | Select-Object -ExpandProperty "SaveFilesToHost"
+            | Select-Object -ExpandProperty "SaveFilesToHost"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.44.5"
+    Id   = "18.10.44.5"
     Task = "(NG) Ensure 'Configure Windows Defender Application Guard clipboard settings: Clipboard behavior setting' is set to 'Enabled: Enable clipboard operation from an isolated session to the host'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI" `
                 -Name "AppHVSIClipboardSettings" `
-                | Select-Object -ExpandProperty "AppHVSIClipboardSettings"
+            | Select-Object -ExpandProperty "AppHVSIClipboardSettings"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.44.6"
+    Id   = "18.10.44.6"
     Task = "(NG) Ensure 'Turn on Microsoft Defender Application Guard in Managed Mode' is set to 'Enabled: 1'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\AppHVSI" `
                 -Name "AllowAppHVSI_ProviderSet" `
-                | Select-Object -ExpandProperty "AllowAppHVSI_ProviderSet"
+            | Select-Object -ExpandProperty "AllowAppHVSI_ProviderSet"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.50.1"
+    Id   = "18.10.50.1"
     Task = "(L2) Ensure 'Enable news and interests on the taskbar' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Feeds" `
                 -Name "EnableFeeds" `
-                | Select-Object -ExpandProperty "EnableFeeds"
+            | Select-Object -ExpandProperty "EnableFeeds"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.51.1"
+    Id   = "18.10.51.1"
     Task = "(L1) Ensure 'Prevent the usage of OneDrive for file storage' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\OneDrive" `
                 -Name "DisableFileSyncNGSC" `
-                | Select-Object -ExpandProperty "DisableFileSyncNGSC"
+            | Select-Object -ExpandProperty "DisableFileSyncNGSC"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.56.1"
+    Id   = "18.10.56.1"
     Task = "(L2) Ensure 'Turn off Push To Install service' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\PushToInstall" `
                 -Name "DisablePushToInstall" `
-                | Select-Object -ExpandProperty "DisablePushToInstall"
+            | Select-Object -ExpandProperty "DisablePushToInstall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.2.2"
+    Id   = "18.10.57.2.2"
     Task = "(L1) Ensure 'Do not allow passwords to be saved' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "DisablePasswordSaving" `
-                | Select-Object -ExpandProperty "DisablePasswordSaving"
+            | Select-Object -ExpandProperty "DisablePasswordSaving"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.2.1"
+    Id   = "18.10.57.3.2.1"
     Task = "(L2) Ensure 'Allow users to connect remotely by using Remote Desktop Services' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDenyTSConnections" `
-                | Select-Object -ExpandProperty "fDenyTSConnections"
+            | Select-Object -ExpandProperty "fDenyTSConnections"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.1"
+    Id   = "18.10.57.3.3.1"
     Task = "(L2) Ensure 'Allow UI Automation redirection' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "EnableUiaRedirection" `
-                | Select-Object -ExpandProperty "EnableUiaRedirection"
+            | Select-Object -ExpandProperty "EnableUiaRedirection"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.2"
+    Id   = "18.10.57.3.3.2"
     Task = "(L2) Ensure 'Do not allow COM port redirection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisableCcm" `
-                | Select-Object -ExpandProperty "fDisableCcm"
+            | Select-Object -ExpandProperty "fDisableCcm"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.3"
+    Id   = "18.10.57.3.3.3"
     Task = "(L1) Ensure 'Do not allow drive redirection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisableCdm" `
-                | Select-Object -ExpandProperty "fDisableCdm"
+            | Select-Object -ExpandProperty "fDisableCdm"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.4"
+    Id   = "18.10.57.3.3.4"
     Task = "(L2) Ensure 'Do not allow location redirection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisableLocationRedir" `
-                | Select-Object -ExpandProperty "fDisableLocationRedir"
+            | Select-Object -ExpandProperty "fDisableLocationRedir"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.5"
+    Id   = "18.10.57.3.3.5"
     Task = "(L2) Ensure 'Do not allow LPT port redirection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisableLPT" `
-                | Select-Object -ExpandProperty "fDisableLPT"
+            | Select-Object -ExpandProperty "fDisableLPT"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.6"
+    Id   = "18.10.57.3.3.6"
     Task = "(L2) Ensure 'Do not allow supported Plug and Play device redirection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisablePNPRedir" `
-                | Select-Object -ExpandProperty "fDisablePNPRedir"
+            | Select-Object -ExpandProperty "fDisablePNPRedir"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.3.7"
+    Id   = "18.10.57.3.3.7"
     Task = "(L2) Ensure 'Do not allow WebAuthn redirection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisableWebAuthn" `
-                | Select-Object -ExpandProperty "fDisableWebAuthn"
+            | Select-Object -ExpandProperty "fDisableWebAuthn"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.9.1"
+    Id   = "18.10.57.3.9.1"
     Task = "(L1) Ensure 'Always prompt for password upon connection' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fPromptForPassword" `
-                | Select-Object -ExpandProperty "fPromptForPassword"
+            | Select-Object -ExpandProperty "fPromptForPassword"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.9.2"
+    Id   = "18.10.57.3.9.2"
     Task = "(L1) Ensure 'Require secure RPC communication' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fEncryptRPCTraffic" `
-                | Select-Object -ExpandProperty "fEncryptRPCTraffic"
+            | Select-Object -ExpandProperty "fEncryptRPCTraffic"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.9.3"
+    Id   = "18.10.57.3.9.3"
     Task = "(L1) Ensure 'Require use of specific security layer for remote (RDP) connections' is set to 'Enabled: SSL'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "SecurityLayer" `
-                | Select-Object -ExpandProperty "SecurityLayer"
+            | Select-Object -ExpandProperty "SecurityLayer"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.9.4"
+    Id   = "18.10.57.3.9.4"
     Task = "(L1) Ensure 'Require user authentication for remote connections by using Network Level Authentication' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "UserAuthentication" `
-                | Select-Object -ExpandProperty "UserAuthentication"
+            | Select-Object -ExpandProperty "UserAuthentication"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.9.5"
+    Id   = "18.10.57.3.9.5"
     Task = "(L1) Ensure 'Set client connection encryption level' is set to 'Enabled: High Level'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "MinEncryptionLevel" `
-                | Select-Object -ExpandProperty "MinEncryptionLevel"
+            | Select-Object -ExpandProperty "MinEncryptionLevel"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.10.1"
+    Id   = "18.10.57.3.10.1"
     Task = "(L2) Ensure 'Set time limit for active but idle Remote Desktop Services sessions' is set to 'Enabled: 15 minutes or less, but not Never (0)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "MaxIdleTime" `
-                | Select-Object -ExpandProperty "MaxIdleTime"
+            | Select-Object -ExpandProperty "MaxIdleTime"
         
             if (($regValue -gt 900000 -or $regValue -eq 0)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x <= 900000 and x != 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.10.2"
+    Id   = "18.10.57.3.10.2"
     Task = "(L2) Ensure 'Set time limit for disconnected sessions' is set to 'Enabled: 1 minute'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "MaxDisconnectionTime" `
-                | Select-Object -ExpandProperty "MaxDisconnectionTime"
+            | Select-Object -ExpandProperty "MaxDisconnectionTime"
         
             if ($regValue -ne 60000) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 60000"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.57.3.11.1"
+    Id   = "18.10.57.3.11.1"
     Task = "(L1) Ensure 'Do not delete temp folders upon exit' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "DeleteTempDirsOnExit" `
-                | Select-Object -ExpandProperty "DeleteTempDirsOnExit"
+            | Select-Object -ExpandProperty "DeleteTempDirsOnExit"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.58.1"
+    Id   = "18.10.58.1"
     Task = "(L1) Ensure 'Prevent downloading of enclosures' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Internet Explorer\Feeds" `
                 -Name "DisableEnclosureDownload" `
-                | Select-Object -ExpandProperty "DisableEnclosureDownload"
+            | Select-Object -ExpandProperty "DisableEnclosureDownload"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.59.2"
+    Id   = "18.10.59.2"
     Task = "(L2) Ensure 'Allow Cloud Search' is set to 'Enabled: Disable Cloud Search'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" `
                 -Name "AllowCloudSearch" `
-                | Select-Object -ExpandProperty "AllowCloudSearch"
+            | Select-Object -ExpandProperty "AllowCloudSearch"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.59.3"
+    Id   = "18.10.59.3"
     Task = "(L1) Ensure 'Allow Cortana' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" `
                 -Name "AllowCortana" `
-                | Select-Object -ExpandProperty "AllowCortana"
+            | Select-Object -ExpandProperty "AllowCortana"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.59.4"
+    Id   = "18.10.59.4"
     Task = "(L1) Ensure 'Allow Cortana above lock screen' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" `
                 -Name "AllowCortanaAboveLock" `
-                | Select-Object -ExpandProperty "AllowCortanaAboveLock"
+            | Select-Object -ExpandProperty "AllowCortanaAboveLock"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.59.5"
+    Id   = "18.10.59.5"
     Task = "(L1) Ensure 'Allow indexing of encrypted files' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" `
                 -Name "AllowIndexingEncryptedStoresOrItems" `
-                | Select-Object -ExpandProperty "AllowIndexingEncryptedStoresOrItems"
+            | Select-Object -ExpandProperty "AllowIndexingEncryptedStoresOrItems"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.59.6"
+    Id   = "18.10.59.6"
     Task = "(L1) Ensure 'Allow search and Cortana to use location' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" `
                 -Name "AllowSearchToUseLocation" `
-                | Select-Object -ExpandProperty "AllowSearchToUseLocation"
+            | Select-Object -ExpandProperty "AllowSearchToUseLocation"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.59.7"
+    Id   = "18.10.59.7"
     Task = "(L2) Ensure 'Allow search highlights' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Windows Search" `
                 -Name "EnableDynamicContentInWSB" `
-                | Select-Object -ExpandProperty "EnableDynamicContentInWSB"
+            | Select-Object -ExpandProperty "EnableDynamicContentInWSB"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.63.1"
+    Id   = "18.10.63.1"
     Task = "(L2) Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\CurrentVersion\Software Protection Platform" `
                 -Name "NoGenTicket" `
-                | Select-Object -ExpandProperty "NoGenTicket"
+            | Select-Object -ExpandProperty "NoGenTicket"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.66.1"
+    Id   = "18.10.66.1"
     Task = "(L2) Ensure 'Disable all apps from Microsoft Store' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore" `
                 -Name "DisableStoreApps" `
-                | Select-Object -ExpandProperty "DisableStoreApps"
+            | Select-Object -ExpandProperty "DisableStoreApps"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.66.2"
+    Id   = "18.10.66.2"
     Task = "(L1) Ensure 'Only display the private store within the Microsoft Store' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore" `
                 -Name "RequirePrivateStoreOnly" `
-                | Select-Object -ExpandProperty "RequirePrivateStoreOnly"
+            | Select-Object -ExpandProperty "RequirePrivateStoreOnly"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.66.3"
+    Id   = "18.10.66.3"
     Task = "(L1) Ensure 'Turn off Automatic Download and Install of updates' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore" `
                 -Name "AutoDownload" `
-                | Select-Object -ExpandProperty "AutoDownload"
+            | Select-Object -ExpandProperty "AutoDownload"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.66.4"
+    Id   = "18.10.66.4"
     Task = "(L1) Ensure 'Turn off the offer to update to the latest version of Windows' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore" `
                 -Name "DisableOSUpgrade" `
-                | Select-Object -ExpandProperty "DisableOSUpgrade"
+            | Select-Object -ExpandProperty "DisableOSUpgrade"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.66.5"
+    Id   = "18.10.66.5"
     Task = "(L2) Ensure 'Turn off the Store application' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsStore" `
                 -Name "RemoveWindowsStore" `
-                | Select-Object -ExpandProperty "RemoveWindowsStore"
+            | Select-Object -ExpandProperty "RemoveWindowsStore"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.72.1"
+    Id   = "18.10.72.1"
     Task = "(L1) Ensure 'Allow widgets' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Dsh" `
                 -Name "AllowNewsAndInterests" `
-                | Select-Object -ExpandProperty "AllowNewsAndInterests"
+            | Select-Object -ExpandProperty "AllowNewsAndInterests"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.76.2.1 A"
+    Id   = "18.10.76.2.1 A"
     Task = "(L1) Ensure 'Configure Windows Defender SmartScreen' is set to 'Enabled: Warn and prevent bypass' (EnableSmartScreen)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "EnableSmartScreen" `
-                | Select-Object -ExpandProperty "EnableSmartScreen"
+            | Select-Object -ExpandProperty "EnableSmartScreen"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.76.2.1 B"
+    Id   = "18.10.76.2.1 B"
     Task = "(L1) Ensure 'Configure Windows Defender SmartScreen' is set to 'Enabled: Warn and prevent bypass' (ShellSmartScreenLevel)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" `
                 -Name "ShellSmartScreenLevel" `
-                | Select-Object -ExpandProperty "ShellSmartScreenLevel"
+            | Select-Object -ExpandProperty "ShellSmartScreenLevel"
         
             if ($regValue -ne "Block") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: Block"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.76.3.1"
+    Id   = "18.10.76.3.1"
     Task = "(L1) Ensure 'Configure Windows Defender SmartScreen' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MicrosoftEdge\PhishingFilter" `
                 -Name "EnabledV9" `
-                | Select-Object -ExpandProperty "EnabledV9"
+            | Select-Object -ExpandProperty "EnabledV9"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.76.3.2"
+    Id   = "18.10.76.3.2"
     Task = "(L1) Ensure 'Prevent bypassing Windows Defender SmartScreen prompts for sites' is set to 'Enabled' (PreventOverride)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\MicrosoftEdge\PhishingFilter" `
                 -Name "PreventOverride" `
-                | Select-Object -ExpandProperty "PreventOverride"
+            | Select-Object -ExpandProperty "PreventOverride"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.78.1"
+    Id   = "18.10.78.1"
     Task = "(L1) Ensure 'Enables or disables Windows Game Recording and Broadcasting' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\GameDVR" `
                 -Name "AllowGameDVR" `
-                | Select-Object -ExpandProperty "AllowGameDVR"
+            | Select-Object -ExpandProperty "AllowGameDVR"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.80.1"
+    Id   = "18.10.80.1"
     Task = "(L2) Ensure 'Allow suggested apps in Windows Ink Workspace' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsInkWorkspace" `
                 -Name "AllowSuggestedAppsInWindowsInkWorkspace" `
-                | Select-Object -ExpandProperty "AllowSuggestedAppsInWindowsInkWorkspace"
+            | Select-Object -ExpandProperty "AllowSuggestedAppsInWindowsInkWorkspace"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.80.2"
+    Id   = "18.10.80.2"
     Task = "(L1) Ensure 'Allow Windows Ink Workspace' is set to 'Enabled: On, but disallow access above lock' OR 'Enabled: Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\WindowsInkWorkspace" `
                 -Name "AllowWindowsInkWorkspace" `
-                | Select-Object -ExpandProperty "AllowWindowsInkWorkspace"
+            | Select-Object -ExpandProperty "AllowWindowsInkWorkspace"
         
             if (($regValue -ne 1) -and ($regValue -ne 0)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 1 or x == 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.81.1"
+    Id   = "18.10.81.1"
     Task = "(L1) Ensure 'Allow user control over installs' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer" `
                 -Name "EnableUserControl" `
-                | Select-Object -ExpandProperty "EnableUserControl"
+            | Select-Object -ExpandProperty "EnableUserControl"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.81.2"
+    Id   = "18.10.81.2"
     Task = "(L1) Ensure 'Always install with elevated privileges' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer" `
                 -Name "AlwaysInstallElevated" `
-                | Select-Object -ExpandProperty "AlwaysInstallElevated"
+            | Select-Object -ExpandProperty "AlwaysInstallElevated"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.81.3"
+    Id   = "18.10.81.3"
     Task = "(L2) Ensure 'Prevent Internet Explorer security prompt for Windows Installer scripts' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer" `
                 -Name "SafeForScripting" `
-                | Select-Object -ExpandProperty "SafeForScripting"
+            | Select-Object -ExpandProperty "SafeForScripting"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.82.1"
+    Id   = "18.10.82.1"
     Task = "(L1) Ensure 'Enable MPR notifications for the system' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableMPR" `
-                | Select-Object -ExpandProperty "EnableMPR"
+            | Select-Object -ExpandProperty "EnableMPR"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.82.2"
+    Id   = "18.10.82.2"
     Task = "(L1) Ensure 'Sign-in and lock last interactive user automatically after a restart' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "DisableAutomaticRestartSignOn" `
-                | Select-Object -ExpandProperty "DisableAutomaticRestartSignOn"
+            | Select-Object -ExpandProperty "DisableAutomaticRestartSignOn"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.87.1"
+    Id   = "18.10.87.1"
     Task = "(L1) Ensure 'Turn on PowerShell Script Block Logging' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" `
                 -Name "EnableScriptBlockLogging" `
-                | Select-Object -ExpandProperty "EnableScriptBlockLogging"
+            | Select-Object -ExpandProperty "EnableScriptBlockLogging"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.87.2"
+    Id   = "18.10.87.2"
     Task = "(L1) Ensure 'Turn on PowerShell Transcription' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\PowerShell\Transcription" `
                 -Name "EnableTranscripting" `
-                | Select-Object -ExpandProperty "EnableTranscripting"
+            | Select-Object -ExpandProperty "EnableTranscripting"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.1.1"
+    Id   = "18.10.89.1.1"
     Task = "(L1) Ensure 'Allow Basic authentication' is set to 'Disabled' (Client)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client" `
                 -Name "AllowBasic" `
-                | Select-Object -ExpandProperty "AllowBasic"
+            | Select-Object -ExpandProperty "AllowBasic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.1.2"
+    Id   = "18.10.89.1.2"
     Task = "(L1) Ensure 'Allow unencrypted traffic' is set to 'Disabled' (Client)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client" `
                 -Name "AllowUnencryptedTraffic" `
-                | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
+            | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.1.3"
+    Id   = "18.10.89.1.3"
     Task = "(L1) Ensure 'Disallow Digest authentication' is set to 'Enabled' (Client)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client" `
                 -Name "AllowDigest" `
-                | Select-Object -ExpandProperty "AllowDigest"
+            | Select-Object -ExpandProperty "AllowDigest"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.2.1"
+    Id   = "18.10.89.2.1"
     Task = "(L1) Ensure 'Allow Basic authentication' is set to 'Disabled' (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "AllowBasic" `
-                | Select-Object -ExpandProperty "AllowBasic"
+            | Select-Object -ExpandProperty "AllowBasic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.2.2"
+    Id   = "18.10.89.2.2"
     Task = "(L2) Ensure 'Allow remote server management through WinRM' is set to 'Disabled' (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "AllowAutoConfig" `
-                | Select-Object -ExpandProperty "AllowAutoConfig"
+            | Select-Object -ExpandProperty "AllowAutoConfig"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.2.3"
+    Id   = "18.10.89.2.3"
     Task = "(L1) Ensure 'Allow unencrypted traffic' is set to 'Disabled' (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "AllowUnencryptedTraffic" `
-                | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
+            | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.89.2.4"
+    Id   = "18.10.89.2.4"
     Task = "(L1) Ensure 'Disallow WinRM from storing RunAs credentials' is set to 'Enabled' (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "DisableRunAs" `
-                | Select-Object -ExpandProperty "DisableRunAs"
+            | Select-Object -ExpandProperty "DisableRunAs"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.90.1"
+    Id   = "18.10.90.1"
     Task = "(L2) Ensure 'Allow Remote Shell Access' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service\WinRS" `
                 -Name "AllowRemoteShellAccess" `
-                | Select-Object -ExpandProperty "AllowRemoteShellAccess"
+            | Select-Object -ExpandProperty "AllowRemoteShellAccess"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.91.1"
+    Id   = "18.10.91.1"
     Task = "(L1) Ensure 'Allow clipboard sharing with Windows Sandbox' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Sandbox" `
                 -Name "AllowClipboardRedirection" `
-                | Select-Object -ExpandProperty "AllowClipboardRedirection"
+            | Select-Object -ExpandProperty "AllowClipboardRedirection"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.91.2"
+    Id   = "18.10.91.2"
     Task = "(L1) Ensure 'Allow networking in Windows Sandbox' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Sandbox" `
                 -Name "AllowNetworking" `
-                | Select-Object -ExpandProperty "AllowNetworking"
+            | Select-Object -ExpandProperty "AllowNetworking"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.92.2.1"
+    Id   = "18.10.92.2.1"
     Task = "(L1) Ensure 'Prevent users from modifying settings' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\App and Browser protection" `
                 -Name "DisallowExploitProtectionOverride" `
-                | Select-Object -ExpandProperty "DisallowExploitProtectionOverride"
+            | Select-Object -ExpandProperty "DisallowExploitProtectionOverride"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.1.1"
+    Id   = "18.10.93.1.1"
     Task = "(L1) Ensure 'No auto-restart with logged on users for scheduled automatic updates installations' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU" `
                 -Name "NoAutoRebootWithLoggedOnUsers" `
-                | Select-Object -ExpandProperty "NoAutoRebootWithLoggedOnUsers"
+            | Select-Object -ExpandProperty "NoAutoRebootWithLoggedOnUsers"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.2.1"
+    Id   = "18.10.93.2.1"
     Task = "(L1) Ensure 'Configure Automatic Updates' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU" `
                 -Name "NoAutoUpdate" `
-                | Select-Object -ExpandProperty "NoAutoUpdate"
+            | Select-Object -ExpandProperty "NoAutoUpdate"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.2.2"
+    Id   = "18.10.93.2.2"
     Task = "(L1) Ensure 'Configure Automatic Updates: Scheduled install day' is set to '0 - Every day'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU" `
                 -Name "ScheduledInstallDay" `
-                | Select-Object -ExpandProperty "ScheduledInstallDay"
+            | Select-Object -ExpandProperty "ScheduledInstallDay"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.2.3"
+    Id   = "18.10.93.2.3"
     Task = "(L1) Ensure 'Remove access to `"Pause updates`" feature' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" `
                 -Name "SetDisablePauseUXAccess" `
-                | Select-Object -ExpandProperty "SetDisablePauseUXAccess"
+            | Select-Object -ExpandProperty "SetDisablePauseUXAccess"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.4.1"
+    Id   = "18.10.93.4.1"
     Task = "(L1) Ensure 'Manage preview builds' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate" `
                 -Name "ManagePreviewBuildsPolicyValue" `
-                | Select-Object -ExpandProperty "ManagePreviewBuildsPolicyValue"
+            | Select-Object -ExpandProperty "ManagePreviewBuildsPolicyValue"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.4.2 A"
+    Id   = "18.10.93.4.2 A"
     Task = "(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: 180 or more days' (DeferFeatureUpdates)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate" `
                 -Name "DeferFeatureUpdates" `
-                | Select-Object -ExpandProperty "DeferFeatureUpdates"
+            | Select-Object -ExpandProperty "DeferFeatureUpdates"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.4.2 B"
+    Id   = "18.10.93.4.2 B"
     Task = "(L1) Ensure 'Select when Preview Builds and Feature Updates are received' is set to 'Enabled: 180 or more days' (DeferFeatureUpdatesPeriodInDays)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate" `
                 -Name "DeferFeatureUpdatesPeriodInDays" `
-                | Select-Object -ExpandProperty "DeferFeatureUpdatesPeriodInDays"
+            | Select-Object -ExpandProperty "DeferFeatureUpdatesPeriodInDays"
         
             if (($regValue -lt 180 -or $regValue -gt 365)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x >= 180 and x <= 365"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.4.3 A"
+    Id   = "18.10.93.4.3 A"
     Task = "(L1) Ensure 'Select when Quality Updates are received' is set to 'Enabled: 0 days' (DeferQualityUpdates)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate" `
                 -Name "DeferQualityUpdates" `
-                | Select-Object -ExpandProperty "DeferQualityUpdates"
+            | Select-Object -ExpandProperty "DeferQualityUpdates"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "18.10.93.4.3 B"
+    Id   = "18.10.93.4.3 B"
     Task = "(L1) Ensure 'Select when Quality Updates are received' is set to 'Enabled: 0 days' (DeferQualityUpdatesPeriodInDays)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate" `
                 -Name "DeferQualityUpdatesPeriodInDays" `
-                | Select-Object -ExpandProperty "DeferQualityUpdatesPeriodInDays"
+            | Select-Object -ExpandProperty "DeferQualityUpdatesPeriodInDays"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.1.3.1"
+    Id   = "19.1.3.1"
     Task = "(L1) Ensure 'Enable screen saver' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\Control Panel\Desktop" `
                 -Name "ScreenSaveActive" `
-                | Select-Object -ExpandProperty "ScreenSaveActive"
+            | Select-Object -ExpandProperty "ScreenSaveActive"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.1.3.2"
+    Id   = "19.1.3.2"
     Task = "(L1) Ensure 'Password protect the screen saver' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\Control Panel\Desktop" `
                 -Name "ScreenSaverIsSecure" `
-                | Select-Object -ExpandProperty "ScreenSaverIsSecure"
+            | Select-Object -ExpandProperty "ScreenSaverIsSecure"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.5.1.1"
+    Id   = "19.5.1.1"
     Task = "(L1) Ensure 'Turn off toast notifications on the lock screen' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications" `
                 -Name "NoToastApplicationNotificationOnLockScreen" `
-                | Select-Object -ExpandProperty "NoToastApplicationNotificationOnLockScreen"
+            | Select-Object -ExpandProperty "NoToastApplicationNotificationOnLockScreen"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.6.6.1.1"
+    Id   = "19.6.6.1.1"
     Task = "(L2) Ensure 'Turn off Help Experience Improvement Program' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Assistance\Client\1.0" `
                 -Name "NoImplicitFeedback" `
-                | Select-Object -ExpandProperty "NoImplicitFeedback"
+            | Select-Object -ExpandProperty "NoImplicitFeedback"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.4.1"
+    Id   = "19.7.4.1"
     Task = "(L1) Ensure 'Do not preserve zone information in file attachments' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments" `
                 -Name "SaveZoneInformation" `
-                | Select-Object -ExpandProperty "SaveZoneInformation"
+            | Select-Object -ExpandProperty "SaveZoneInformation"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.4.2"
+    Id   = "19.7.4.2"
     Task = "(L1) Ensure 'Notify antivirus programs when opening attachments' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments" `
                 -Name "ScanWithAntiVirus" `
-                | Select-Object -ExpandProperty "ScanWithAntiVirus"
+            | Select-Object -ExpandProperty "ScanWithAntiVirus"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.7.1"
+    Id   = "19.7.7.1"
     Task = "(L1) Ensure 'Configure Windows spotlight on lock screen' is set to Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "ConfigureWindowsSpotlight" `
-                | Select-Object -ExpandProperty "ConfigureWindowsSpotlight"
+            | Select-Object -ExpandProperty "ConfigureWindowsSpotlight"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.7.2"
+    Id   = "19.7.7.2"
     Task = "(L1) Ensure 'Do not suggest third-party content in Windows spotlight' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableThirdPartySuggestions" `
-                | Select-Object -ExpandProperty "DisableThirdPartySuggestions"
+            | Select-Object -ExpandProperty "DisableThirdPartySuggestions"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.7.3"
+    Id   = "19.7.7.3"
     Task = "(L2) Ensure 'Do not use diagnostic data for tailored experiences' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableTailoredExperiencesWithDiagnosticData" `
-                | Select-Object -ExpandProperty "DisableTailoredExperiencesWithDiagnosticData"
+            | Select-Object -ExpandProperty "DisableTailoredExperiencesWithDiagnosticData"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.7.4"
+    Id   = "19.7.7.4"
     Task = "(L2) Ensure 'Turn off all Windows spotlight features' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableWindowsSpotlightFeatures" `
-                | Select-Object -ExpandProperty "DisableWindowsSpotlightFeatures"
+            | Select-Object -ExpandProperty "DisableWindowsSpotlightFeatures"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.7.5"
+    Id   = "19.7.7.5"
     Task = "(L1) Ensure 'Turn off Spotlight collection on Desktop' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableSpotlightCollectionOnDesktop" `
-                | Select-Object -ExpandProperty "DisableSpotlightCollectionOnDesktop"
+            | Select-Object -ExpandProperty "DisableSpotlightCollectionOnDesktop"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.25.1"
+    Id   = "19.7.25.1"
     Task = "(L1) Ensure 'Prevent users from sharing files within their profile.' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoInplaceSharing" `
-                | Select-Object -ExpandProperty "NoInplaceSharing"
+            | Select-Object -ExpandProperty "NoInplaceSharing"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.40.1"
+    Id   = "19.7.40.1"
     Task = "(L1) Ensure 'Always install with elevated privileges' is set to 'Disabled' (AlwaysInstallElevated)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\Installer" `
                 -Name "AlwaysInstallElevated" `
-                | Select-Object -ExpandProperty "AlwaysInstallElevated"
+            | Select-Object -ExpandProperty "AlwaysInstallElevated"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "19.7.42.2.1"
+    Id   = "19.7.42.2.1"
     Task = "(L2) Ensure 'Prevent Codec Download' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\WindowsMediaPlayer" `
                 -Name "PreventCodecDownload" `
-                | Select-Object -ExpandProperty "PreventCodecDownload"
+            | Select-Object -ExpandProperty "PreventCodecDownload"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 10-Stand-alone-CIS-2.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 10-Stand-alone-CIS-2.0.0#RegistrySettings.ps1
@@ -12397,13 +12397,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550" `
-            | Select-Object -ExpandProperty "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
-        
-            if ($regValue -ne "1") {
+
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-4.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-CIS-4.0.0#RegistrySettings.ps1
@@ -13690,7 +13690,7 @@ $windefrunning = CheckWindefRunning
                 Status  = "False"
             }
         }
-
+        
         return @{
             Message = "Compliant"
             Status  = "True"
@@ -13736,14 +13736,42 @@ $windefrunning = CheckWindefRunning
 [AuditTest] @{
     Id   = "18.10.43.6.1.2 B"
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from creating executable content'"
-    Test = {
+        Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "3b576869-a4ec-4529-8536-b80a7769e899" `
-            | Select-Object -ExpandProperty "3b576869-a4ec-4529-8536-b80a7769e899"
+            if ($avstatus) {
 
-            if ($regValue -ne "1") {
+                if ((-not $windefrunning)) {
+                    return @{
+                        Message = "This rule requires Windows Defender Antivirus to be enabled."
+                        Status  = "None"
+                    }
+                }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "3b576869-a4ec-4529-8536-b80a7769e899"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
+            }
+
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "3b576869-a4ec-4529-8536-b80a7769e899"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -13762,7 +13790,7 @@ $windefrunning = CheckWindefRunning
                 Status  = "False"
             }
         }
-
+        
         return @{
             Message = "Compliant"
             Status  = "True"

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-Microsoft-22H2#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-Microsoft-22H2#RegistrySettings.ps1
@@ -5,5046 +5,5046 @@ $avstatus = CheckForActiveAV
 $windefrunning = CheckWindefRunning
 . "$RootPath\Helpers\Firewall.ps1"
 [AuditTest] @{
-    Id = "Registry-001"
+    Id   = "Registry-001"
     Task = "Turn off Connect to suggested open hotspots and Connect to networks shared by my contacts"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WcmSvc\wifinetworkmanager\config" `
                 -Name "AutoConnectAllowedOEM" `
-                | Select-Object -ExpandProperty "AutoConnectAllowedOEM"
+            | Select-Object -ExpandProperty "AutoConnectAllowedOEM"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-002"
+    Id   = "Registry-002"
     Task = "Ensure 'Enumerate administrator accounts on elevation' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\CredUI" `
                 -Name "EnumerateAdministrators" `
-                | Select-Object -ExpandProperty "EnumerateAdministrators"
+            | Select-Object -ExpandProperty "EnumerateAdministrators"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-003"
+    Id   = "Registry-003"
     Task = "Ensure 'Turn off Autoplay' is set to 'All drives'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoDriveTypeAutoRun" `
-                | Select-Object -ExpandProperty "NoDriveTypeAutoRun"
+            | Select-Object -ExpandProperty "NoDriveTypeAutoRun"
         
             if ($regValue -ne 255) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 255"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-004"
+    Id   = "Registry-004"
     Task = "Ensure 'Turn off Internet download for Web publishing and online ordering wizards' set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoWebServices" `
-                | Select-Object -ExpandProperty "NoWebServices"
+            | Select-Object -ExpandProperty "NoWebServices"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-005"
+    Id   = "Registry-005"
     Task = "Ensure 'Set the default behavior for AutoRun' is set to 'Enabled: Do not execute any autorun commands'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" `
                 -Name "NoAutorun" `
-                | Select-Object -ExpandProperty "NoAutorun"
+            | Select-Object -ExpandProperty "NoAutorun"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-006"
+    Id   = "Registry-006"
     Task = "Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "MSAOptional" `
-                | Select-Object -ExpandProperty "MSAOptional"
+            | Select-Object -ExpandProperty "MSAOptional"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-007"
+    Id   = "Registry-007"
     Task = "Ensure 'Sign-in last interactive user automatically after a system-initiated restart' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "DisableAutomaticRestartSignOn" `
-                | Select-Object -ExpandProperty "DisableAutomaticRestartSignOn"
+            | Select-Object -ExpandProperty "DisableAutomaticRestartSignOn"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-008"
+    Id   = "Registry-008"
     Task = "Local administrator accounts must have their privileged token filtered to prevent elevated privileges from being used over the network on domain systems."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "LocalAccountTokenFilterPolicy" `
-                | Select-Object -ExpandProperty "LocalAccountTokenFilterPolicy"
+            | Select-Object -ExpandProperty "LocalAccountTokenFilterPolicy"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-009"
+    Id   = "Registry-009"
     Task = "Ensure 'Enable MPR notifications for the system' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableMPR" `
-                | Select-Object -ExpandProperty "EnableMPR"
+            | Select-Object -ExpandProperty "EnableMPR"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-010"
+    Id   = "Registry-010"
     Task = "Ensure 'Encryption Oracle Remediation' is set to 'Force Updated Clients'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\CredSSP\Parameters" `
                 -Name "AllowEncryptionOracle" `
-                | Select-Object -ExpandProperty "AllowEncryptionOracle"
+            | Select-Object -ExpandProperty "AllowEncryptionOracle"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-011"
+    Id   = "Registry-011"
     Task = "Ensure 'Configure enhanced anti-spoofing' set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Biometrics\FacialFeatures" `
                 -Name "EnhancedAntiSpoofing" `
-                | Select-Object -ExpandProperty "EnhancedAntiSpoofing"
+            | Select-Object -ExpandProperty "EnhancedAntiSpoofing"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-012"
+    Id   = "Registry-012"
     Task = "Ensure 'Prevent downloading of enclosures' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Feeds" `
                 -Name "DisableEnclosureDownload" `
-                | Select-Object -ExpandProperty "DisableEnclosureDownload"
+            | Select-Object -ExpandProperty "DisableEnclosureDownload"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-013"
+    Id   = "Registry-013"
     Task = "Ensure 'Require a password when a computer wakes (on battery)' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51" `
                 -Name "DCSettingIndex" `
-                | Select-Object -ExpandProperty "DCSettingIndex"
+            | Select-Object -ExpandProperty "DCSettingIndex"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-014"
+    Id   = "Registry-014"
     Task = "Ensure 'Require a password when a computer wakes (plugged in)' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\0e796bdb-100d-47d6-a2d5-f7d2daa51f51" `
                 -Name "ACSettingIndex" `
-                | Select-Object -ExpandProperty "ACSettingIndex"
+            | Select-Object -ExpandProperty "ACSettingIndex"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-015"
+    Id   = "Registry-015"
     Task = "Ensure 'Let Windows apps activate with voice while the system is locked' is set to 'Force Deny'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\AppPrivacy" `
                 -Name "LetAppsActivateWithVoiceAboveLock" `
-                | Select-Object -ExpandProperty "LetAppsActivateWithVoiceAboveLock"
+            | Select-Object -ExpandProperty "LetAppsActivateWithVoiceAboveLock"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-016"
+    Id   = "Registry-016"
     Task = "Ensure 'Turn off Microsoft consumer experiences' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableWindowsConsumerFeatures" `
-                | Select-Object -ExpandProperty "DisableWindowsConsumerFeatures"
+            | Select-Object -ExpandProperty "DisableWindowsConsumerFeatures"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-017"
+    Id   = "Registry-017"
     Task = "Ensure 'Remote host allows delegation of non-exportable credentials' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CredentialsDelegation" `
                 -Name "AllowProtectedCreds" `
-                | Select-Object -ExpandProperty "AllowProtectedCreds"
+            | Select-Object -ExpandProperty "AllowProtectedCreds"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-018"
+    Id   = "Registry-018"
     Task = "Ensure 'Specify the maximum log file size (KB)' is set to '32768' (Application)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Application" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if ($regValue -ne 32768) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 32768"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-019"
+    Id   = "Registry-019"
     Task = "Ensure 'Specify the maximum log file size (KB)' is set to '196608' (Security)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\Security" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if ($regValue -ne 196608) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 196608"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-020"
+    Id   = "Registry-020"
     Task = "Ensure 'Specify the maximum log file size (KB)' is set to '32768' (System)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\EventLog\System" `
                 -Name "MaxSize" `
-                | Select-Object -ExpandProperty "MaxSize"
+            | Select-Object -ExpandProperty "MaxSize"
         
             if ($regValue -ne 32768) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 32768"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-021"
+    Id   = "Registry-021"
     Task = "Ensure 'Disallow Autoplay for non-volume devices' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Explorer" `
                 -Name "NoAutoplayfornonVolume" `
-                | Select-Object -ExpandProperty "NoAutoplayfornonVolume"
+            | Select-Object -ExpandProperty "NoAutoplayfornonVolume"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-022"
+    Id   = "Registry-022"
     Task = "Ensure 'Windows Game Recording and Broadcasting' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\GameDVR" `
                 -Name "AllowGameDVR" `
-                | Select-Object -ExpandProperty "AllowGameDVR"
+            | Select-Object -ExpandProperty "AllowGameDVR"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-023"
+    Id   = "Registry-023"
     Task = "Ensure 'Configure registry policy processing: Process even if the Group Policy objects have not changed' is set to 'Enabled: TRUE'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}" `
                 -Name "NoGPOListChanges" `
-                | Select-Object -ExpandProperty "NoGPOListChanges"
+            | Select-Object -ExpandProperty "NoGPOListChanges"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-024"
+    Id   = "Registry-024"
     Task = "Ensure 'Configure registry policy processing' is set to '0'. (NoBackgroundPolicy)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Group Policy\{35378EAC-683F-11D2-A89A-00C04FBBCFA2}" `
                 -Name "NoBackgroundPolicy" `
-                | Select-Object -ExpandProperty "NoBackgroundPolicy"
+            | Select-Object -ExpandProperty "NoBackgroundPolicy"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-025"
+    Id   = "Registry-025"
     Task = "Ensure 'Always install with elevated privileges' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer" `
                 -Name "AlwaysInstallElevated" `
-                | Select-Object -ExpandProperty "AlwaysInstallElevated"
+            | Select-Object -ExpandProperty "AlwaysInstallElevated"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-026"
+    Id   = "Registry-026"
     Task = "Ensure 'Allow user control over installs' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Installer" `
                 -Name "EnableUserControl" `
-                | Select-Object -ExpandProperty "EnableUserControl"
+            | Select-Object -ExpandProperty "EnableUserControl"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-027"
+    Id   = "Registry-027"
     Task = "Ensure 'Enumeration policy for external devices incompatible with Kernel DMA Protection' is set to 'Block all'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Kernel DMA Protection" `
                 -Name "DeviceEnumerationPolicy" `
-                | Select-Object -ExpandProperty "DeviceEnumerationPolicy"
+            | Select-Object -ExpandProperty "DeviceEnumerationPolicy"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-028"
+    Id   = "Registry-028"
     Task = "Ensure 'Enable insecure guest logons' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\LanmanWorkstation" `
                 -Name "AllowInsecureGuestAuth" `
-                | Select-Object -ExpandProperty "AllowInsecureGuestAuth"
+            | Select-Object -ExpandProperty "AllowInsecureGuestAuth"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-029"
+    Id   = "Registry-029"
     Task = "Ensure 'Prohibit use of Internet Connection Sharing on your DNS domain network' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Network Connections" `
                 -Name "NC_ShowSharedAccessUI" `
-                | Select-Object -ExpandProperty "NC_ShowSharedAccessUI"
+            | Select-Object -ExpandProperty "NC_ShowSharedAccessUI"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-030"
+    Id   = "Registry-030"
     Task = "Set registry value '\\*\SYSVOL' to RequireMutualAuthentication=1, RequireIntegrity=1."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths" `
                 -Name "\\*\SYSVOL" `
-                | Select-Object -ExpandProperty "\\*\SYSVOL"
+            | Select-Object -ExpandProperty "\\*\SYSVOL"
         
             if ($regValue -ne "RequireMutualAuthentication=1, RequireIntegrity=1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: RequireMutualAuthentication=1, RequireIntegrity=1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-031"
+    Id   = "Registry-031"
     Task = "Set registry value '\\*\NETLOGON' to RequireMutualAuthentication=1,RequireIntegrity=1."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\NetworkProvider\HardenedPaths" `
                 -Name "\\*\NETLOGON" `
-                | Select-Object -ExpandProperty "\\*\NETLOGON"
+            | Select-Object -ExpandProperty "\\*\NETLOGON"
         
             if ($regValue -ne "RequireMutualAuthentication=1, RequireIntegrity=1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: RequireMutualAuthentication=1, RequireIntegrity=1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-032"
+    Id   = "Registry-032"
     Task = "Ensure 'Prevent enabling lock screen camera' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Personalization" `
                 -Name "NoLockScreenCamera" `
-                | Select-Object -ExpandProperty "NoLockScreenCamera"
+            | Select-Object -ExpandProperty "NoLockScreenCamera"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-033"
+    Id   = "Registry-033"
     Task = "Ensure 'Prevent enabling lock screen slide show' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Personalization" `
                 -Name "NoLockScreenSlideshow" `
-                | Select-Object -ExpandProperty "NoLockScreenSlideshow"
+            | Select-Object -ExpandProperty "NoLockScreenSlideshow"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-034"
+    Id   = "Registry-034"
     Task = "Ensure 'Turn on PowerShell Script Block Logging' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" `
                 -Name "EnableScriptBlockLogging" `
-                | Select-Object -ExpandProperty "EnableScriptBlockLogging"
+            | Select-Object -ExpandProperty "EnableScriptBlockLogging"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-035"
+    Id   = "Registry-035"
     Task = "Ensure 'Turn on PowerShell Script Block Logging' is not set."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging" `
                 -Name "EnableScriptBlockInvocationLogging" `
-                | Select-Object -ExpandProperty "EnableScriptBlockInvocationLogging"
+            | Select-Object -ExpandProperty "EnableScriptBlockInvocationLogging"
         
             return @{
                 Message = "Registry value found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-036"
+    Id   = "Registry-036"
     Task = "Ensure 'Turn on convenience PIN sign-in' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System" `
                 -Name "AllowDomainPINLogon" `
-                | Select-Object -ExpandProperty "AllowDomainPINLogon"
+            | Select-Object -ExpandProperty "AllowDomainPINLogon"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-037"
+    Id   = "Registry-037"
     Task = "Ensure 'Enumerate local users on domain-joined computers' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System" `
                 -Name "EnumerateLocalUsers" `
-                | Select-Object -ExpandProperty "EnumerateLocalUsers"
+            | Select-Object -ExpandProperty "EnumerateLocalUsers"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-038"
+    Id   = "Registry-038"
     Task = "Ensure 'Configure Windows SmartScreen' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System" `
                 -Name "EnableSmartScreen" `
-                | Select-Object -ExpandProperty "EnableSmartScreen"
+            | Select-Object -ExpandProperty "EnableSmartScreen"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-039"
+    Id   = "Registry-039"
     Task = "Ensure 'Configure Windows Defender SmartScreen' is set to 'Block'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System" `
                 -Name "ShellSmartScreenLevel" `
-                | Select-Object -ExpandProperty "ShellSmartScreenLevel"
+            | Select-Object -ExpandProperty "ShellSmartScreenLevel"
         
             if ($regValue -ne "Block") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: Block"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-040"
+    Id   = "Registry-040"
     Task = "Ensure 'Allow Custom SSPs and APs to be loaded into LSASS' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System" `
                 -Name "AllowCustomSSPsAPs" `
-                | Select-Object -ExpandProperty "AllowCustomSSPsAPs"
+            | Select-Object -ExpandProperty "AllowCustomSSPsAPs"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-041"
+    Id   = "Registry-041"
     Task = "Ensure 'Prohibit connection to non-domain networks when connected to domain authenticated network' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WcmSvc\GroupPolicy" `
                 -Name "fBlockNonDomain" `
-                | Select-Object -ExpandProperty "fBlockNonDomain"
+            | Select-Object -ExpandProperty "fBlockNonDomain"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-042"
+    Id   = "Registry-042"
     Task = "Ensure 'Allow indexing of encrypted files' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\Windows Search" `
                 -Name "AllowIndexingEncryptedStoresOrItems" `
-                | Select-Object -ExpandProperty "AllowIndexingEncryptedStoresOrItems"
+            | Select-Object -ExpandProperty "AllowIndexingEncryptedStoresOrItems"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-043"
+    Id   = "Registry-043"
     Task = "Ensure 'Disallow Digest authentication' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client" `
                 -Name "AllowDigest" `
-                | Select-Object -ExpandProperty "AllowDigest"
+            | Select-Object -ExpandProperty "AllowDigest"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-044"
+    Id   = "Registry-044"
     Task = "Ensure 'Allow unencrypted traffic' is set to 'Disabled'. (Client)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client" `
                 -Name "AllowUnencryptedTraffic" `
-                | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
+            | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-045"
+    Id   = "Registry-045"
     Task = "Ensure 'Allow Basic authentication' is set to 'Disabled'. (Client)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Client" `
                 -Name "AllowBasic" `
-                | Select-Object -ExpandProperty "AllowBasic"
+            | Select-Object -ExpandProperty "AllowBasic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-046"
+    Id   = "Registry-046"
     Task = "Ensure 'Allow unencrypted traffic' is set to 'Disabled'. (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "AllowUnencryptedTraffic" `
-                | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
+            | Select-Object -ExpandProperty "AllowUnencryptedTraffic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-047"
+    Id   = "Registry-047"
     Task = "Ensure 'Disallow WinRM from storing RunAs credentials' is set to 'Enabled'. (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "DisableRunAs" `
-                | Select-Object -ExpandProperty "DisableRunAs"
+            | Select-Object -ExpandProperty "DisableRunAs"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-048"
+    Id   = "Registry-048"
     Task = "Ensure 'Allow Basic authentication' is set to 'Disabled'. (Service)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WinRM\Service" `
                 -Name "AllowBasic" `
-                | Select-Object -ExpandProperty "AllowBasic"
+            | Select-Object -ExpandProperty "AllowBasic"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-049"
+    Id   = "Registry-049"
     Task = "Ensure 'Notify Malicious' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WTDS\Components" `
                 -Name "NotifyMalicious" `
-                | Select-Object -ExpandProperty "NotifyMalicious"
+            | Select-Object -ExpandProperty "NotifyMalicious"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-050"
+    Id   = "Registry-050"
     Task = "Ensure 'Notify Password Reuse' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WTDS\Components" `
                 -Name "NotifyPasswordReuse" `
-                | Select-Object -ExpandProperty "NotifyPasswordReuse"
+            | Select-Object -ExpandProperty "NotifyPasswordReuse"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-051"
+    Id   = "Registry-051"
     Task = "Ensure 'Notify Unsafe App' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WTDS\Components" `
                 -Name "NotifyUnsafeApp" `
-                | Select-Object -ExpandProperty "NotifyUnsafeApp"
+            | Select-Object -ExpandProperty "NotifyUnsafeApp"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-052"
+    Id   = "Registry-052"
     Task = "Ensure 'Service Enabled' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WTDS\Components" `
                 -Name "ServiceEnabled" `
-                | Select-Object -ExpandProperty "ServiceEnabled"
+            | Select-Object -ExpandProperty "ServiceEnabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-053"
+    Id   = "Registry-053"
     Task = "Ensure 'Turn off multicast name resolution' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\DNSClient" `
                 -Name "EnableMulticast" `
-                | Select-Object -ExpandProperty "EnableMulticast"
+            | Select-Object -ExpandProperty "EnableMulticast"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-054"
+    Id   = "Registry-054"
     Task = "Set registry value 'EnableNetBIOS' to 2."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\DNSClient" `
                 -Name "EnableNetBIOS" `
-                | Select-Object -ExpandProperty "EnableNetBIOS"
+            | Select-Object -ExpandProperty "EnableNetBIOS"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-055"
+    Id   = "Registry-055"
     Task = "Ensure 'Turn off downloading of print drivers over HTTP' set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers" `
                 -Name "DisableWebPnPDownload" `
-                | Select-Object -ExpandProperty "DisableWebPnPDownload"
+            | Select-Object -ExpandProperty "DisableWebPnPDownload"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-056"
+    Id   = "Registry-056"
     Task = "Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirection Guard Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers" `
                 -Name "RedirectionGuardPolicy" `
-                | Select-Object -ExpandProperty "RedirectionGuardPolicy"
+            | Select-Object -ExpandProperty "RedirectionGuardPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-057"
+    Id   = "Registry-057"
     Task = "Ensure 'Manage processing of Queue-specific files' is set to 'Enabled: Limit Queue-specific files to Color profiles'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers" `
                 -Name "CopyFilesPolicy" `
-                | Select-Object -ExpandProperty "CopyFilesPolicy"
+            | Select-Object -ExpandProperty "CopyFilesPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-058"
+    Id   = "Registry-058"
     Task = "Ensure 'Limits print driver installation to Administrators' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\PointAndPrint" `
                 -Name "RestrictDriverInstallationToAdministrators" `
-                | Select-Object -ExpandProperty "RestrictDriverInstallationToAdministrators"
+            | Select-Object -ExpandProperty "RestrictDriverInstallationToAdministrators"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-059"
+    Id   = "Registry-059"
     Task = "Set registry value 'RpcUseNamedPipeProtocol' to 0."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcUseNamedPipeProtocol" `
-                | Select-Object -ExpandProperty "RpcUseNamedPipeProtocol"
+            | Select-Object -ExpandProperty "RpcUseNamedPipeProtocol"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-060"
+    Id   = "Registry-060"
     Task = "Ensure 'Configure RPC connection settings: Use authentication for outgoing RPC connections' is set to 'Enabled: Default'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcAuthentication" `
-                | Select-Object -ExpandProperty "RpcAuthentication"
+            | Select-Object -ExpandProperty "RpcAuthentication"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-061"
+    Id   = "Registry-061"
     Task = "Ensure 'Configure RPC listener settings: Protocols to allow for incoming RPC connections' is set to 'Enabled: RPC over TCP'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcProtocols" `
-                | Select-Object -ExpandProperty "RpcProtocols"
+            | Select-Object -ExpandProperty "RpcProtocols"
         
             if ($regValue -ne 5) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 5"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-062"
+    Id   = "Registry-062"
     Task = "Set registry value 'ForceKerberosForRpc' to 0."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "ForceKerberosForRpc" `
-                | Select-Object -ExpandProperty "ForceKerberosForRpc"
+            | Select-Object -ExpandProperty "ForceKerberosForRpc"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-063"
+    Id   = "Registry-063"
     Task = "Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\Printers\RPC" `
                 -Name "RpcTcpPort" `
-                | Select-Object -ExpandProperty "RpcTcpPort"
+            | Select-Object -ExpandProperty "RpcTcpPort"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-064"
+    Id   = "Registry-064"
     Task = "Ensure 'Restrict Unauthenticated RPC clients' is set to 'Authenticated'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Rpc" `
                 -Name "RestrictRemoteClients" `
-                | Select-Object -ExpandProperty "RestrictRemoteClients"
+            | Select-Object -ExpandProperty "RestrictRemoteClients"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-065"
+    Id   = "Registry-065"
     Task = "Solicited Remote Assistance - Set method for sending email invitations to 'Simple MAPI'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fUseMailto" `
-                | Select-Object -ExpandProperty "fUseMailto"
+            | Select-Object -ExpandProperty "fUseMailto"
         
             return @{
                 Message = "Registry value found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-066"
+    Id   = "Registry-066"
     Task = "Solicited Remote Assistance must not be allowed."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fAllowToGetHelp" `
-                | Select-Object -ExpandProperty "fAllowToGetHelp"
+            | Select-Object -ExpandProperty "fAllowToGetHelp"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-067"
+    Id   = "Registry-067"
     Task = "Ensure 'Configure Solicited Remote Assistance' is not set (fAllowFullControl)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fAllowFullControl" `
-                | Select-Object -ExpandProperty "fAllowFullControl"
+            | Select-Object -ExpandProperty "fAllowFullControl"
         
             return @{
                 Message = "Registry value found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-068"
+    Id   = "Registry-068"
     Task = "Ensure 'Configure Solicited Remote Assistance' is not set (MaxTicketExpiry)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "MaxTicketExpiry" `
-                | Select-Object -ExpandProperty "MaxTicketExpiry"
+            | Select-Object -ExpandProperty "MaxTicketExpiry"
         
             return @{
                 Message = "Registry value found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-069"
+    Id   = "Registry-069"
     Task = "Ensure 'Configure Solicited Remote Assistance' is not set (MaxTicketExpiryUnits)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "MaxTicketExpiryUnits" `
-                | Select-Object -ExpandProperty "MaxTicketExpiryUnits"
+            | Select-Object -ExpandProperty "MaxTicketExpiryUnits"
         
             return @{
                 Message = "Registry value found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Compliant. Registry value not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Compliant. Registry key not found."
-                Status = "True"
+                Status  = "True"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-070"
+    Id   = "Registry-070"
     Task = "Ensure 'Set client connection encryption level' is set to 'High Level'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "MinEncryptionLevel" `
-                | Select-Object -ExpandProperty "MinEncryptionLevel"
+            | Select-Object -ExpandProperty "MinEncryptionLevel"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-071"
+    Id   = "Registry-071"
     Task = "Ensure 'Always prompt for password upon connection' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fPromptForPassword" `
-                | Select-Object -ExpandProperty "fPromptForPassword"
+            | Select-Object -ExpandProperty "fPromptForPassword"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-072"
+    Id   = "Registry-072"
     Task = "Ensure 'Do not allow drive redirection' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fDisableCdm" `
-                | Select-Object -ExpandProperty "fDisableCdm"
+            | Select-Object -ExpandProperty "fDisableCdm"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-073"
+    Id   = "Registry-073"
     Task = "Ensure 'Do not allow passwords to be saved' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "DisablePasswordSaving" `
-                | Select-Object -ExpandProperty "DisablePasswordSaving"
+            | Select-Object -ExpandProperty "DisablePasswordSaving"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-074"
+    Id   = "Registry-074"
     Task = "Ensure 'Require secure RPC communication' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows NT\Terminal Services" `
                 -Name "fEncryptRPCTraffic" `
-                | Select-Object -ExpandProperty "fEncryptRPCTraffic"
+            | Select-Object -ExpandProperty "fEncryptRPCTraffic"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-076"
+    Id   = "Registry-076"
     Task = "Ensure 'Windows Firewall: Domain: Outbound connections' is set to 'Allow'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile" `
                 -Name "DefaultOutboundAction" `
-                | Select-Object -ExpandProperty "DefaultOutboundAction"
+            | Select-Object -ExpandProperty "DefaultOutboundAction"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-077"
+    Id   = "Registry-077"
     Task = "Ensure 'Windows Defender Firewall: Prohibit notifications' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile" `
                 -Name "DisableNotifications" `
-                | Select-Object -ExpandProperty "DisableNotifications"
+            | Select-Object -ExpandProperty "DisableNotifications"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-078"
+    Id   = "Registry-078"
     Task = "Ensure 'Windows Defender Firewall: Protect all network connections' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile" `
                 -Name "EnableFirewall" `
-                | Select-Object -ExpandProperty "EnableFirewall"
+            | Select-Object -ExpandProperty "EnableFirewall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-079"
+    Id   = "Registry-079"
     Task = "Ensure 'Windows Firewall: Domain: Inbound connections' is set to 'Block (default)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile" `
                 -Name "DefaultInboundAction" `
-                | Select-Object -ExpandProperty "DefaultInboundAction"
+            | Select-Object -ExpandProperty "DefaultInboundAction"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-080"
+    Id   = "Registry-080"
     Task = "Ensure 'Windows Firewall: Domain: Logging: Log dropped packets' is set to 'Yes'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging" `
                 -Name "LogDroppedPackets" `
-                | Select-Object -ExpandProperty "LogDroppedPackets"
+            | Select-Object -ExpandProperty "LogDroppedPackets"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-081"
+    Id   = "Registry-081"
     Task = "Ensure 'Windows Defender Firewall: Allow logging' is set to '16384' (LogFileSize)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging" `
                 -Name "LogFileSize" `
-                | Select-Object -ExpandProperty "LogFileSize"
+            | Select-Object -ExpandProperty "LogFileSize"
         
             if ($regValue -ne 16384) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 16384"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-082"
+    Id   = "Registry-082"
     Task = "Ensure 'Windows Firewall: Domain: Logging: Log successful connections' is set to 'Yes'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile\Logging" `
                 -Name "LogSuccessfulConnections" `
-                | Select-Object -ExpandProperty "LogSuccessfulConnections"
+            | Select-Object -ExpandProperty "LogSuccessfulConnections"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-083"
+    Id   = "Registry-083"
     Task = "Ensure 'Windows Firewall: Private: Firewall state' is set to 'On (recommended)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile" `
                 -Name "EnableFirewall" `
-                | Select-Object -ExpandProperty "EnableFirewall"
+            | Select-Object -ExpandProperty "EnableFirewall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-084"
+    Id   = "Registry-084"
     Task = "Private: Set registry value 'DisableNotifications' to 1."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile" `
                 -Name "DisableNotifications" `
-                | Select-Object -ExpandProperty "DisableNotifications"
+            | Select-Object -ExpandProperty "DisableNotifications"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-085"
+    Id   = "Registry-085"
     Task = "Ensure 'Windows Firewall: Private: Inbound connections' is set to 'Block (default)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile" `
                 -Name "DefaultInboundAction" `
-                | Select-Object -ExpandProperty "DefaultInboundAction"
+            | Select-Object -ExpandProperty "DefaultInboundAction"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-086"
+    Id   = "Registry-086"
     Task = "Ensure 'Windows Firewall: Private: Outbound connections' is set to 'Allow (default)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile" `
                 -Name "DefaultOutboundAction" `
-                | Select-Object -ExpandProperty "DefaultOutboundAction"
+            | Select-Object -ExpandProperty "DefaultOutboundAction"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-087"
+    Id   = "Registry-087"
     Task = "Ensure 'Windows Firewall: Private: Logging: Log successful connections' is set to 'Yes'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging" `
                 -Name "LogSuccessfulConnections" `
-                | Select-Object -ExpandProperty "LogSuccessfulConnections"
+            | Select-Object -ExpandProperty "LogSuccessfulConnections"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-088"
+    Id   = "Registry-088"
     Task = "Ensure 'Windows Firewall: Private: Logging: Log dropped packets' is set to 'Yes'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging" `
                 -Name "LogDroppedPackets" `
-                | Select-Object -ExpandProperty "LogDroppedPackets"
+            | Select-Object -ExpandProperty "LogDroppedPackets"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-089"
+    Id   = "Registry-089"
     Task = "Set registry value 'LogFileSize' to 16384."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\Logging" `
                 -Name "LogFileSize" `
-                | Select-Object -ExpandProperty "LogFileSize"
+            | Select-Object -ExpandProperty "LogFileSize"
         
             if ($regValue -ne 16384) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 16384"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-090"
+    Id   = "Registry-090"
     Task = "Ensure 'Windows Firewall: Public: Outbound connections' is set to 'Allow (default)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile" `
                 -Name "DefaultOutboundAction" `
-                | Select-Object -ExpandProperty "DefaultOutboundAction"
+            | Select-Object -ExpandProperty "DefaultOutboundAction"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-091"
+    Id   = "Registry-091"
     Task = "Ensure 'Windows Firewall: Public: Firewall state' is set to 'On (recommended)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile" `
                 -Name "EnableFirewall" `
-                | Select-Object -ExpandProperty "EnableFirewall"
+            | Select-Object -ExpandProperty "EnableFirewall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-092"
+    Id   = "Registry-092"
     Task = "Public: Set registry value 'DisableNotifications' to 1."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile" `
                 -Name "DisableNotifications" `
-                | Select-Object -ExpandProperty "DisableNotifications"
+            | Select-Object -ExpandProperty "DisableNotifications"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-093"
+    Id   = "Registry-093"
     Task = "Ensure 'Windows Firewall: Public: Settings: Apply local connection security rules' is set to 'No'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile" `
                 -Name "AllowLocalIPsecPolicyMerge" `
-                | Select-Object -ExpandProperty "AllowLocalIPsecPolicyMerge"
+            | Select-Object -ExpandProperty "AllowLocalIPsecPolicyMerge"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-094"
+    Id   = "Registry-094"
     Task = "Ensure 'Windows Firewall: Public: Settings: Apply local firewall rules' is set to 'No'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile" `
                 -Name "AllowLocalPolicyMerge" `
-                | Select-Object -ExpandProperty "AllowLocalPolicyMerge"
+            | Select-Object -ExpandProperty "AllowLocalPolicyMerge"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-095"
+    Id   = "Registry-095"
     Task = "Ensure 'Windows Firewall: Public: Inbound connections' is set to 'Block (default)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile" `
                 -Name "DefaultInboundAction" `
-                | Select-Object -ExpandProperty "DefaultInboundAction"
+            | Select-Object -ExpandProperty "DefaultInboundAction"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-096"
+    Id   = "Registry-096"
     Task = "Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' set to '16,384'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging" `
                 -Name "LogFileSize" `
-                | Select-Object -ExpandProperty "LogFileSize"
+            | Select-Object -ExpandProperty "LogFileSize"
         
             if ($regValue -ne 16384) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 16384"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-097"
+    Id   = "Registry-097"
     Task = "Ensure 'Windows Firewall: Public: Logging: Log dropped packets' is set to 'Yes'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging" `
                 -Name "LogDroppedPackets" `
-                | Select-Object -ExpandProperty "LogDroppedPackets"
+            | Select-Object -ExpandProperty "LogDroppedPackets"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-098"
+    Id   = "Registry-098"
     Task = "Ensure 'Windows Firewall: Public: Logging: Log successful connections' is set to 'Yes'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\Logging" `
                 -Name "LogSuccessfulConnections" `
-                | Select-Object -ExpandProperty "LogSuccessfulConnections"
+            | Select-Object -ExpandProperty "LogSuccessfulConnections"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-099"
+    Id   = "Registry-099"
     Task = "Ensure 'Allow Windows Ink Workspace' is set to 'On, but disallow access above lock'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsInkWorkspace" `
                 -Name "AllowWindowsInkWorkspace" `
-                | Select-Object -ExpandProperty "AllowWindowsInkWorkspace"
+            | Select-Object -ExpandProperty "AllowWindowsInkWorkspace"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-100"
+    Id   = "Registry-100"
     Task = "Ensure 'Enable local admin password management' set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft Services\AdmPwd" `
                 -Name "AdmPwdEnabled" `
-                | Select-Object -ExpandProperty "AdmPwdEnabled"
+            | Select-Object -ExpandProperty "AdmPwdEnabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-101"
+    Id   = "Registry-101"
     Task = "Ensure 'Configures LSASS to run as a protected process' is set to 'Enabled: Enabled with UEFI Lock'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "RunAsPPL" `
-                | Select-Object -ExpandProperty "RunAsPPL"
+            | Select-Object -ExpandProperty "RunAsPPL"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-102"
+    Id   = "Registry-102"
     Task = "Ensure 'Configure RPC packet level privacy setting for incoming connections' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Print" `
                 -Name "RpcAuthnLevelPrivacyEnabled" `
-                | Select-Object -ExpandProperty "RpcAuthnLevelPrivacyEnabled"
+            | Select-Object -ExpandProperty "RpcAuthnLevelPrivacyEnabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-103"
+    Id   = "Registry-103"
     Task = "Ensure 'WDigest Authentication (disabling may require KB2871997)' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest" `
                 -Name "UseLogonCredential" `
-                | Select-Object -ExpandProperty "UseLogonCredential"
+            | Select-Object -ExpandProperty "UseLogonCredential"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-104"
+    Id   = "Registry-104"
     Task = "Ensure 'Enable Structured Exception Handling Overwrite Protection (SEHOP)' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\kernel" `
                 -Name "DisableExceptionChainValidation" `
-                | Select-Object -ExpandProperty "DisableExceptionChainValidation"
+            | Select-Object -ExpandProperty "DisableExceptionChainValidation"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-105"
+    Id   = "Registry-105"
     Task = "Ensure 'Boot-Start Driver Initialization Policy' is set to 'Enabled: Good, unknown and bad but critical'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Policies\EarlyLaunch" `
                 -Name "DriverLoadPolicy" `
-                | Select-Object -ExpandProperty "DriverLoadPolicy"
+            | Select-Object -ExpandProperty "DriverLoadPolicy"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-106"
+    Id   = "Registry-106"
     Task = "Ensure 'Configure SMB v1 server' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" `
                 -Name "SMB1" `
-                | Select-Object -ExpandProperty "SMB1"
+            | Select-Object -ExpandProperty "SMB1"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-107"
+    Id   = "Registry-107"
     Task = "Ensure 'Configure SMB v1 client driver' is set to 'Disable driver (recommended)'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\MrxSmb10" `
                 -Name "Start" `
-                | Select-Object -ExpandProperty "Start"
+            | Select-Object -ExpandProperty "Start"
         
             if ($regValue -ne 4) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 4"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-108"
+    Id   = "Registry-108"
     Task = "Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore NetBIOS name release requests except from WINS servers' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Netbt\Parameters" `
                 -Name "NoNameReleaseOnDemand" `
-                | Select-Object -ExpandProperty "NoNameReleaseOnDemand"
+            | Select-Object -ExpandProperty "NoNameReleaseOnDemand"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-109"
+    Id   = "Registry-109"
     Task = "Ensure 'NetBT NodeType configuration' is set to 'P-node (recommended)'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Netbt\Parameters" `
                 -Name "NodeType" `
-                | Select-Object -ExpandProperty "NodeType"
+            | Select-Object -ExpandProperty "NodeType"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-110"
+    Id   = "Registry-110"
     Task = "Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to override OSPF generated routes' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "EnableICMPRedirect" `
-                | Select-Object -ExpandProperty "EnableICMPRedirect"
+            | Select-Object -ExpandProperty "EnableICMPRedirect"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-111"
+    Id   = "Registry-111"
     Task = "Ensure 'MSS: (DisableIPSourceRouting) IP source routing protection level (protects against packet spoofing)' is set to 'Highest protection, source routing is completely disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" `
                 -Name "DisableIPSourceRouting" `
-                | Select-Object -ExpandProperty "DisableIPSourceRouting"
+            | Select-Object -ExpandProperty "DisableIPSourceRouting"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-112"
+    Id   = "Registry-112"
     Task = "Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing protection level (protects against packet spoofing)' is set to 'Highest protection, source routing is completely disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters" `
                 -Name "DisableIPSourceRouting" `
-                | Select-Object -ExpandProperty "DisableIPSourceRouting"
+            | Select-Object -ExpandProperty "DisableIPSourceRouting"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-113"
+    Id   = "Registry-113"
     Task = "Ensure 'Interactive logon: Smart card removal behavior' is set to 'Lock Workstation'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" `
                 -Name "ScRemoveOption" `
-                | Select-Object -ExpandProperty "ScRemoveOption"
+            | Select-Object -ExpandProperty "ScRemoveOption"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-114"
+    Id   = "Registry-114"
     Task = "The machine inactivity limit must be set to 15 minutes, locking the system with the screensaver."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "InactivityTimeoutSecs" `
-                | Select-Object -ExpandProperty "InactivityTimeoutSecs"
+            | Select-Object -ExpandProperty "InactivityTimeoutSecs"
         
             if (($regValue -ne 900)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 900"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-115"
+    Id   = "Registry-115"
     Task = "Ensure 'Network security: Do not store LAN Manager hash value on next password change' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "NoLMHash" `
-                | Select-Object -ExpandProperty "NoLMHash"
+            | Select-Object -ExpandProperty "NoLMHash"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-116"
+    Id   = "Registry-116"
     Task = "Ensure 'Microsoft network client: Send unencrypted password to third-party SMB servers' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
                 -Name "EnablePlainTextPassword" `
-                | Select-Object -ExpandProperty "EnablePlainTextPassword"
+            | Select-Object -ExpandProperty "EnablePlainTextPassword"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-117"
+    Id   = "Registry-117"
     Task = "Ensure 'Accounts: Limit local account use of blank passwords to console logon only' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "LimitBlankPasswordUse" `
-                | Select-Object -ExpandProperty "LimitBlankPasswordUse"
+            | Select-Object -ExpandProperty "LimitBlankPasswordUse"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-118"
+    Id   = "Registry-118"
     Task = "Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "RestrictAnonymousSAM" `
-                | Select-Object -ExpandProperty "RestrictAnonymousSAM"
+            | Select-Object -ExpandProperty "RestrictAnonymousSAM"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-119"
+    Id   = "Registry-119"
     Task = "Ensure 'Network access: Do not allow anonymous enumeration of SAM accounts and shares' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "RestrictAnonymous" `
-                | Select-Object -ExpandProperty "RestrictAnonymous"
+            | Select-Object -ExpandProperty "RestrictAnonymous"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-120"
+    Id   = "Registry-120"
     Task = "Ensure 'Network access: Restrict anonymous access to Named Pipes and Shares' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "RestrictNullSessAccess" `
-                | Select-Object -ExpandProperty "RestrictNullSessAccess"
+            | Select-Object -ExpandProperty "RestrictNullSessAccess"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-121"
+    Id   = "Registry-121"
     Task = "Ensure 'Audit: Force audit policy subcategory settings (Windows Vista or later) to override audit policy category settings' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "SCENoApplyLegacyAuditPolicy" `
-                | Select-Object -ExpandProperty "SCENoApplyLegacyAuditPolicy"
+            | Select-Object -ExpandProperty "SCENoApplyLegacyAuditPolicy"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-122"
+    Id   = "Registry-122"
     Task = "The system must be configured to meet the minimum session security requirement for NTLM SSP-based clients."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0" `
                 -Name "NTLMMinClientSec" `
-                | Select-Object -ExpandProperty "NTLMMinClientSec"
+            | Select-Object -ExpandProperty "NTLMMinClientSec"
         
             if (($regValue -ne 537395200)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 537395200"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-123"
+    Id   = "Registry-123"
     Task = "(ND, NE) Ensure 'Network security: LAN Manager authentication level' is set to 'Send NTLMv2 response only'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa" `
                 -Name "LmCompatibilityLevel" `
-                | Select-Object -ExpandProperty "LmCompatibilityLevel"
+            | Select-Object -ExpandProperty "LmCompatibilityLevel"
         
             if ($regValue -ne 5) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 5"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-124"
+    Id   = "Registry-124"
     Task = "Ensure 'Network security: Allow LocalSystem NULL session fallback' is set to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0" `
                 -Name "allownullsessionfallback" `
-                | Select-Object -ExpandProperty "allownullsessionfallback"
+            | Select-Object -ExpandProperty "allownullsessionfallback"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-125"
+    Id   = "Registry-125"
     Task = "Ensure 'Network security: Minimum session security for NTLM SSP based (including secure RPC) servers' is set to 'Require NTLMv2 session security, Require 128-bit encryption'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0" `
                 -Name "NTLMMinServerSec" `
-                | Select-Object -ExpandProperty "NTLMMinServerSec"
+            | Select-Object -ExpandProperty "NTLMMinServerSec"
         
             if (($regValue -ne 537395200)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 537395200"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-126"
+    Id   = "Registry-126"
     Task = "Ensure 'Domain member: Require strong (Windows 2000 or later) session key' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters" `
                 -Name "RequireStrongKey" `
-                | Select-Object -ExpandProperty "RequireStrongKey"
+            | Select-Object -ExpandProperty "RequireStrongKey"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-127"
+    Id   = "Registry-127"
     Task = "Ensure 'Microsoft network client: Digitally sign communications (always)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters" `
                 -Name "RequireSecuritySignature" `
-                | Select-Object -ExpandProperty "RequireSecuritySignature"
+            | Select-Object -ExpandProperty "RequireSecuritySignature"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-128"
+    Id   = "Registry-128"
     Task = "Ensure 'Domain member: Digitally encrypt secure channel data (when possible)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters" `
                 -Name "sealsecurechannel" `
-                | Select-Object -ExpandProperty "sealsecurechannel"
+            | Select-Object -ExpandProperty "sealsecurechannel"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-129"
+    Id   = "Registry-129"
     Task = "Ensure 'Domain member: Digitally encrypt or sign secure channel data (always)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters" `
                 -Name "RequireSignOrSeal" `
-                | Select-Object -ExpandProperty "RequireSignOrSeal"
+            | Select-Object -ExpandProperty "RequireSignOrSeal"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-130"
+    Id   = "Registry-130"
     Task = "Ensure 'Domain member: Digitally sign secure channel data (when possible)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters" `
                 -Name "SignSecureChannel" `
-                | Select-Object -ExpandProperty "SignSecureChannel"
+            | Select-Object -ExpandProperty "SignSecureChannel"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-131"
+    Id   = "Registry-131"
     Task = "Ensure 'Microsoft network server: Digitally sign communications (always)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
                 -Name "RequireSecuritySignature" `
-                | Select-Object -ExpandProperty "RequireSecuritySignature"
+            | Select-Object -ExpandProperty "RequireSecuritySignature"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-132"
+    Id   = "Registry-132"
     Task = "Ensure 'System objects: Strengthen default permissions of internal system objects (e.g. Symbolic Links)' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager" `
                 -Name "ProtectionMode" `
-                | Select-Object -ExpandProperty "ProtectionMode"
+            | Select-Object -ExpandProperty "ProtectionMode"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-133"
+    Id   = "Registry-133"
     Task = "Ensure 'User Account Control: Behavior of the elevation prompt for administrators in Admin Approval Mode' is set to 'Prompt for consent on the secure desktop'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "ConsentPromptBehaviorAdmin" `
-                | Select-Object -ExpandProperty "ConsentPromptBehaviorAdmin"
+            | Select-Object -ExpandProperty "ConsentPromptBehaviorAdmin"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-134"
+    Id   = "Registry-134"
     Task = "Ensure 'User Account Control: Only elevate UIAccess applications that are installed in secure locations' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableSecureUIAPaths" `
-                | Select-Object -ExpandProperty "EnableSecureUIAPaths"
+            | Select-Object -ExpandProperty "EnableSecureUIAPaths"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-135"
+    Id   = "Registry-135"
     Task = "User Account Control must run all administrators in Admin Approval Mode, enabling UAC."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableLUA" `
-                | Select-Object -ExpandProperty "EnableLUA"
+            | Select-Object -ExpandProperty "EnableLUA"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-136"
+    Id   = "Registry-136"
     Task = "Ensure 'User Account Control: Behavior of the elevation prompt for standard users' is set to 'Automatically deny elevation requests'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "ConsentPromptBehaviorUser" `
-                | Select-Object -ExpandProperty "ConsentPromptBehaviorUser"
+            | Select-Object -ExpandProperty "ConsentPromptBehaviorUser"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-137"
+    Id   = "Registry-137"
     Task = "User Account Control must be configured to detect application installations and prompt for elevation"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableInstallerDetection" `
-                | Select-Object -ExpandProperty "EnableInstallerDetection"
+            | Select-Object -ExpandProperty "EnableInstallerDetection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-138"
+    Id   = "Registry-138"
     Task = "Ensure 'User Account Control: Admin Approval Mode for the Built-in Administrator account' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "FilterAdministratorToken" `
-                | Select-Object -ExpandProperty "FilterAdministratorToken"
+            | Select-Object -ExpandProperty "FilterAdministratorToken"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-139"
+    Id   = "Registry-139"
     Task = "User Account Control must virtualize file and registry write failures to per-user locations."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System" `
                 -Name "EnableVirtualization" `
-                | Select-Object -ExpandProperty "EnableVirtualization"
+            | Select-Object -ExpandProperty "EnableVirtualization"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-140"
+    Id   = "Registry-140"
     Task = "Ensure 'Network security: LDAP client signing requirements' is set to 'Negotiate signing'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LDAP" `
                 -Name "LDAPClientIntegrity" `
-                | Select-Object -ExpandProperty "LDAPClientIntegrity"
+            | Select-Object -ExpandProperty "LDAPClientIntegrity"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-141"
+    Id   = "Registry-141"
     Task = "Ensure 'Network access: Restrict clients allowed to make remote calls to SAM' is set to 'Administrators: Remote Access: Allow'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Lsa" `
                 -Name "RestrictRemoteSAM" `
-                | Select-Object -ExpandProperty "RestrictRemoteSAM"
+            | Select-Object -ExpandProperty "RestrictRemoteSAM"
         
             if ($regValue -ne "O:BAG:BAD:(A;;RC;;;BA)") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: O:BAG:BAD:(A;;RC;;;BA)"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-189"
+    Id   = "Registry-189"
     Task = "Ensure 'Configure detection for potentially unwanted applications' is set to 'Enabled: Block'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5052,45 +5052,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender" `
                 -Name "PUAProtection" `
-                | Select-Object -ExpandProperty "PUAProtection"
+            | Select-Object -ExpandProperty "PUAProtection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-190"
+    Id   = "Registry-190"
     Task = "Ensure 'Select cloud protection level' is set to 'Enabled:High blocking level'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5098,45 +5098,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\MpEngine" `
                 -Name "MpCloudBlockLevel" `
-                | Select-Object -ExpandProperty "MpCloudBlockLevel"
+            | Select-Object -ExpandProperty "MpCloudBlockLevel"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-191"
+    Id   = "Registry-191"
     Task = "Ensure 'Scan all downloaded files and attachments' is set to 'Enabled'."
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5144,45 +5144,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableIOAVProtection" `
-                | Select-Object -ExpandProperty "DisableIOAVProtection"
+            | Select-Object -ExpandProperty "DisableIOAVProtection"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-192"
+    Id   = "Registry-192"
     Task = "Ensure 'Turn off real-time protection' is set to 'Disabled'."
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5190,45 +5190,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableRealtimeMonitoring" `
-                | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
+            | Select-Object -ExpandProperty "DisableRealtimeMonitoring"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-193"
+    Id   = "Registry-193"
     Task = "Ensure 'Turn on script scanning' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5236,45 +5236,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableScriptScanning" `
-                | Select-Object -ExpandProperty "DisableScriptScanning"
+            | Select-Object -ExpandProperty "DisableScriptScanning"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-194"
+    Id   = "Registry-194"
     Task = "Ensure 'Turn on behavior monitoring' is set to 'Enabled'."
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5282,45 +5282,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Real-Time Protection" `
                 -Name "DisableBehaviorMonitoring" `
-                | Select-Object -ExpandProperty "DisableBehaviorMonitoring"
+            | Select-Object -ExpandProperty "DisableBehaviorMonitoring"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-195"
+    Id   = "Registry-195"
     Task = "Ensure 'Scan removable drives' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5328,45 +5328,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Scan" `
                 -Name "DisableRemovableDriveScanning" `
-                | Select-Object -ExpandProperty "DisableRemovableDriveScanning"
+            | Select-Object -ExpandProperty "DisableRemovableDriveScanning"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-196"
+    Id   = "Registry-196"
     Task = "Ensure 'Send file samples when further analysis is required' is set to 'Send safe samples'."
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5374,45 +5374,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Spynet" `
                 -Name "SubmitSamplesConsent" `
-                | Select-Object -ExpandProperty "SubmitSamplesConsent"
+            | Select-Object -ExpandProperty "SubmitSamplesConsent"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-197"
+    Id   = "Registry-197"
     Task = "Ensure 'Join Microsoft MAPS' is set to 'Advanced MAPS'."
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5420,45 +5420,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Spynet" `
                 -Name "SpynetReporting" `
-                | Select-Object -ExpandProperty "SpynetReporting"
+            | Select-Object -ExpandProperty "SpynetReporting"
         
             if ($regValue -ne 2) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 2"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-198"
+    Id   = "Registry-198"
     Task = "Ensure 'Configure the 'Block at First Sight' feature' is set to 'Enabled'."
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5466,45 +5466,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Spynet" `
                 -Name "DisableBlockAtFirstSeen" `
-                | Select-Object -ExpandProperty "DisableBlockAtFirstSeen"
+            | Select-Object -ExpandProperty "DisableBlockAtFirstSeen"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-199"
+    Id   = "Registry-199"
     Task = "Ensure 'Configure Attack Surface Reduction rules' is set to 'Enabled'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5512,45 +5512,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR" `
                 -Name "ExploitGuard_ASR_Rules" `
-                | Select-Object -ExpandProperty "ExploitGuard_ASR_Rules"
+            | Select-Object -ExpandProperty "ExploitGuard_ASR_Rules"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-200"
+    Id   = "Registry-200"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from injecting code into other processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5558,45 +5558,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84" `
-                | Select-Object -ExpandProperty "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
+            | Select-Object -ExpandProperty "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-201"
+    Id   = "Registry-201"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from creating executable content'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5604,45 +5604,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "3b576869-a4ec-4529-8536-b80a7769e899" `
-                | Select-Object -ExpandProperty "3b576869-a4ec-4529-8536-b80a7769e899"
+            | Select-Object -ExpandProperty "3b576869-a4ec-4529-8536-b80a7769e899"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-202"
+    Id   = "Registry-202"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from creating child processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5650,45 +5650,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "d4f940ab-401b-4efc-aadc-ad5f3c50688a" `
-                | Select-Object -ExpandProperty "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
+            | Select-Object -ExpandProperty "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-203"
+    Id   = "Registry-203"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block Win32 API calls from Office macro'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5696,45 +5696,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B" `
-                | Select-Object -ExpandProperty "92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B"
+            | Select-Object -ExpandProperty "92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-204"
+    Id   = "Registry-204"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block execution of potentially obfuscated scripts'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5742,45 +5742,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "5beb7efe-fd9a-4556-801d-275e5ffc04cc" `
-                | Select-Object -ExpandProperty "5beb7efe-fd9a-4556-801d-275e5ffc04cc"
+            | Select-Object -ExpandProperty "5beb7efe-fd9a-4556-801d-275e5ffc04cc"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-205"
+    Id   = "Registry-205"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block JavaScript or VBScript from launching downloaded executable content'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5788,45 +5788,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "d3e037e1-3eb8-44c8-a917-57927947596d" `
-                | Select-Object -ExpandProperty "d3e037e1-3eb8-44c8-a917-57927947596d"
+            | Select-Object -ExpandProperty "d3e037e1-3eb8-44c8-a917-57927947596d"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-206"
+    Id   = "Registry-206"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block executable content from email client and webmail'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5834,45 +5834,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550" `
-                | Select-Object -ExpandProperty "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
+            | Select-Object -ExpandProperty "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-207"
+    Id   = "Registry-207"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block credential stealing from the Windows local security authority subsystem (lsass.exe))'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5880,45 +5880,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2" `
-                | Select-Object -ExpandProperty "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
+            | Select-Object -ExpandProperty "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-208"
+    Id   = "Registry-208"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block untrusted and unsigned processes that run from USB' is configured"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5926,45 +5926,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4" `
-                | Select-Object -ExpandProperty "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
+            | Select-Object -ExpandProperty "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-209"
+    Id   = "Registry-209"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block Office communication application from creating child processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -5972,45 +5972,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "26190899-1602-49e8-8b27-eb1d0a1ce869" `
-                | Select-Object -ExpandProperty "26190899-1602-49e8-8b27-eb1d0a1ce869"
+            | Select-Object -ExpandProperty "26190899-1602-49e8-8b27-eb1d0a1ce869"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-210"
+    Id   = "Registry-210"
     Task = "(ND, NE) Ensure 'Configure Attack Surface Reduction rules: Block Adobe Reader from creating child processes'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -6018,45 +6018,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c" `
-                | Select-Object -ExpandProperty "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
+            | Select-Object -ExpandProperty "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-211"
+    Id   = "Registry-211"
     Task = "Ensure 'Configure Attack Surface Reduction rules: Use advanced protection against ransomware'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -6064,45 +6064,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "c1db55ab-c21a-4637-bb3f-a12568109d35" `
-                | Select-Object -ExpandProperty "c1db55ab-c21a-4637-bb3f-a12568109d35"
+            | Select-Object -ExpandProperty "c1db55ab-c21a-4637-bb3f-a12568109d35"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-212"
+    Id   = "Registry-212"
     Task = "Ensure 'Configure Attack Surface Reduction rules: Block persistence through WMI event subscription'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -6110,45 +6110,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "e6db77e5-3df2-4cf1-b95a-636979351e5b" `
-                | Select-Object -ExpandProperty "e6db77e5-3df2-4cf1-b95a-636979351e5b"
+            | Select-Object -ExpandProperty "e6db77e5-3df2-4cf1-b95a-636979351e5b"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-213"
+    Id   = "Registry-213"
     Task = "Ensure 'Configure Attack Surface Reduction rules: Block abuse of exploited vulnerable signed drivers'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -6156,45 +6156,45 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
                 -Name "56a863a9-875e-4185-98a7-b882c64b5ce5" `
-                | Select-Object -ExpandProperty "56a863a9-875e-4185-98a7-b882c64b5ce5"
+            | Select-Object -ExpandProperty "56a863a9-875e-4185-98a7-b882c64b5ce5"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-214"
+    Id   = "Registry-214"
     Task = "Ensure 'Prevent users and apps from accessing dangerous websites' is set to 'Block'"
     Test = {
         try {
-            if($avstatus){
+            if ($avstatus) {
 
                 if ((-not $windefrunning)) {
                     return @{
                         Message = "This rule requires Windows Defender Antivirus to be enabled."
-                        Status = "None"
+                        Status  = "None"
                     }
                 }
             }
@@ -6202,5558 +6202,5558 @@ $windefrunning = CheckWindefRunning
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\Network Protection" `
                 -Name "EnableNetworkProtection" `
-                | Select-Object -ExpandProperty "EnableNetworkProtection"
+            | Select-Object -ExpandProperty "EnableNetworkProtection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-215"
+    Id   = "Registry-215"
     Task = "Ensure 'Remove `"Run this time`" button for outdated ActiveX controls in Internet Explorer ' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Ext" `
                 -Name "RunThisTimeEnabled" `
-                | Select-Object -ExpandProperty "RunThisTimeEnabled"
+            | Select-Object -ExpandProperty "RunThisTimeEnabled"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-216"
+    Id   = "Registry-216"
     Task = "Ensure 'Turn off blocking of outdated ActiveX controls for Internet Explorer' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Ext" `
                 -Name "VersionCheckEnabled" `
-                | Select-Object -ExpandProperty "VersionCheckEnabled"
+            | Select-Object -ExpandProperty "VersionCheckEnabled"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-217"
+    Id   = "Registry-217"
     Task = "Ensure 'Allow software to run or install even if the signature is invalid' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Download" `
                 -Name "RunInvalidSignatures" `
-                | Select-Object -ExpandProperty "RunInvalidSignatures"
+            | Select-Object -ExpandProperty "RunInvalidSignatures"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-218"
+    Id   = "Registry-218"
     Task = "Set registry value 'CheckExeSignatures' to yes."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Download" `
                 -Name "CheckExeSignatures" `
-                | Select-Object -ExpandProperty "CheckExeSignatures"
+            | Select-Object -ExpandProperty "CheckExeSignatures"
         
             if ($regValue -ne "yes") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: yes"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-219"
+    Id   = "Registry-219"
     Task = "Ensure 'Turn on 64-bit tab processes when running in Enhanced Protected Mode on 64-bit versions of Windows' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main" `
                 -Name "Isolation64Bit" `
-                | Select-Object -ExpandProperty "Isolation64Bit"
+            | Select-Object -ExpandProperty "Isolation64Bit"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-220"
+    Id   = "Registry-220"
     Task = "Ensure 'Do not allow ActiveX controls to run in Protected Mode when Enhanced Protected Mode is enabled' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main" `
                 -Name "DisableEPMCompat" `
-                | Select-Object -ExpandProperty "DisableEPMCompat"
+            | Select-Object -ExpandProperty "DisableEPMCompat"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-221"
+    Id   = "Registry-221"
     Task = "Set registry value 'Isolation' to PMEM."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main" `
                 -Name "Isolation" `
-                | Select-Object -ExpandProperty "Isolation"
+            | Select-Object -ExpandProperty "Isolation"
         
             if ($regValue -ne "PMEM") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: PMEM"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-222"
+    Id   = "Registry-222"
     Task = "Ensure 'Internet Explorer Processes for MK protocol' is not enabled (Reserved)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_DISABLE_MK_PROTOCOL" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-223"
+    Id   = "Registry-223"
     Task = "Ensure 'Internet Explorer Processes for MK protocol' is not enabled (iexplore.exe)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_DISABLE_MK_PROTOCOL" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-224"
+    Id   = "Registry-224"
     Task = " Ensure 'Internet Explorer Processes for MK protocol' is not enabled (explorer.exe)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_DISABLE_MK_PROTOCOL" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-225"
+    Id   = "Registry-225"
     Task = "Set registry value 'explorer.exe' to 1."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_MIME_HANDLING" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-226"
+    Id   = "Registry-226"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_MIME_HANDLING)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_MIME_HANDLING" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-227"
+    Id   = "Registry-227"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_MIME_HANDLING)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_MIME_HANDLING" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-228"
+    Id   = "Registry-228"
     Task = "Set registry value 'explorer.exe' to 1. (FEATURE_MIME_SNIFFING)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_MIME_SNIFFING" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-229"
+    Id   = "Registry-229"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_MIME_SNIFFING)"
     Test = {
         try {
-            if((Get-SmbServerConfiguration -ErrorAction Stop).RequireSecuritySignature -ne $True){
+            if ((Get-SmbServerConfiguration -ErrorAction Stop).RequireSecuritySignature -ne $True) {
                 return @{
                     Message = "RequireSecuritySignature is not set to True"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             return @{
                 Message = "Compliant"
-                Status = "True"
+                Status  = "True"
             }
         }
         catch {
-            try{
+            try {
                 $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
-                -Name "RequireSecuritySignature" `
+                    -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\LanManServer\Parameters" `
+                    -Name "RequireSecuritySignature" `
                 | Select-Object -ExpandProperty "RequireSecuritySignature"
                 
                 return @{
                     Message = "Registry value is '$regValue'. Get-SMBServerConfiguration failed, resorted to checking registry, which might not be 100% accurate. See <a href=`"https://learn.microsoft.com/en-us/troubleshoot/windows-server/networking/overview-server-message-block-signing#policy-locations-for-smb-signing`">here</a> and <a href=`"https://techcommunity.microsoft.com/t5/storage-at-microsoft/smb-signing-required-by-default-in-windows-insider/ba-p/3831704`">here</a>"
-                    Status = "Warning"
+                    Status  = "Warning"
                 }
             }
             catch [System.Management.Automation.PSArgumentException] {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
             catch [System.Management.Automation.ItemNotFoundException] {
                 return @{
                     Message = "Registry key not found."
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-230"
+    Id   = "Registry-230"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_MIME_SNIFFING)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_MIME_SNIFFING" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-231"
+    Id   = "Registry-231"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_RESTRICT_ACTIVEXINSTALL)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_RESTRICT_ACTIVEXINSTALL" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-232"
+    Id   = "Registry-232"
     Task = "Set registry value 'explorer.exe' to 1. (FEATURE_RESTRICT_ACTIVEXINSTALL)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_RESTRICT_ACTIVEXINSTALL" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-233"
+    Id   = "Registry-233"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_RESTRICT_ACTIVEXINSTALL)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_RESTRICT_ACTIVEXINSTALL" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-234"
+    Id   = "Registry-234"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_RESTRICT_FILEDOWNLOAD)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_RESTRICT_FILEDOWNLOAD" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-235"
+    Id   = "Registry-235"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_RESTRICT_FILEDOWNLOAD)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_RESTRICT_FILEDOWNLOAD" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-236"
+    Id   = "Registry-236"
     Task = "Set registry value 'explorer.exe' to 1. (FEATURE_RESTRICT_FILEDOWNLOAD)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_RESTRICT_FILEDOWNLOAD" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-237"
+    Id   = "Registry-237"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_SECURITYBAND)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_SECURITYBAND" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-238"
+    Id   = "Registry-238"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_SECURITYBAND)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_SECURITYBAND" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-239"
+    Id   = "Registry-239"
     Task = "Set 'Notification bar' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_SECURITYBAND" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-240"
+    Id   = "Registry-240"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_WINDOW_RESTRICTIONS)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_WINDOW_RESTRICTIONS" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-241"
+    Id   = "Registry-241"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_WINDOW_RESTRICTIONS)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_WINDOW_RESTRICTIONS" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-242"
+    Id   = "Registry-242"
     Task = "Set registry value 'explorer.exe' to 1. (FEATURE_WINDOW_RESTRICTIONS)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_WINDOW_RESTRICTIONS" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-243"
+    Id   = "Registry-243"
     Task = "Set registry value '(Reserved)' to 1. (FEATURE_ZONE_ELEVATION)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ZONE_ELEVATION" `
                 -Name "(Reserved)" `
-                | Select-Object -ExpandProperty "(Reserved)"
+            | Select-Object -ExpandProperty "(Reserved)"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-244"
+    Id   = "Registry-244"
     Task = "Set registry value 'explorer.exe' to 1. (FEATURE_ZONE_ELEVATION)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ZONE_ELEVATION" `
                 -Name "explorer.exe" `
-                | Select-Object -ExpandProperty "explorer.exe"
+            | Select-Object -ExpandProperty "explorer.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-245"
+    Id   = "Registry-245"
     Task = "Set registry value 'iexplore.exe' to 1. (FEATURE_ZONE_ELEVATION)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Main\FeatureControl\FEATURE_ZONE_ELEVATION" `
                 -Name "iexplore.exe" `
-                | Select-Object -ExpandProperty "iexplore.exe"
+            | Select-Object -ExpandProperty "iexplore.exe"
         
             if ($regValue -ne "1") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-246"
+    Id   = "Registry-246"
     Task = "Set 'Prevent bypassing SmartScreen Filter warnings about files that are not commonly downloaded from the Internet' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\PhishingFilter" `
                 -Name "PreventOverrideAppRepUnknown" `
-                | Select-Object -ExpandProperty "PreventOverrideAppRepUnknown"
+            | Select-Object -ExpandProperty "PreventOverrideAppRepUnknown"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-247"
+    Id   = "Registry-247"
     Task = "Set 'Prevent Bypassing SmartScreen Filter Warnings' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\PhishingFilter" `
                 -Name "PreventOverride" `
-                | Select-Object -ExpandProperty "PreventOverride"
+            | Select-Object -ExpandProperty "PreventOverride"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-248"
+    Id   = "Registry-248"
     Task = "Ensure 'Prevent managing SmartScreen Filter' is set to 'On'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\PhishingFilter" `
                 -Name "EnabledV9" `
-                | Select-Object -ExpandProperty "EnabledV9"
+            | Select-Object -ExpandProperty "EnabledV9"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-249"
+    Id   = "Registry-249"
     Task = "Set 'Turn off Crash Detection' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Restrictions" `
                 -Name "NoCrashDetection" `
-                | Select-Object -ExpandProperty "NoCrashDetection"
+            | Select-Object -ExpandProperty "NoCrashDetection"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-250"
+    Id   = "Registry-250"
     Task = "Ensure 'Turn off the Security Settings Check feature' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Security" `
                 -Name "DisableSecuritySettingsCheck" `
-                | Select-Object -ExpandProperty "DisableSecuritySettingsCheck"
+            | Select-Object -ExpandProperty "DisableSecuritySettingsCheck"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-251"
+    Id   = "Registry-251"
     Task = "Ensure 'Prevent per-user installation of ActiveX controls' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Internet Explorer\Security\ActiveX" `
                 -Name "BlockNonAdminActiveXInstall" `
-                | Select-Object -ExpandProperty "BlockNonAdminActiveXInstall"
+            | Select-Object -ExpandProperty "BlockNonAdminActiveXInstall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-252"
+    Id   = "Registry-252"
     Task = "Ensure 'Specify use of ActiveX Installer Service for installation of ActiveX controls' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\AxInstaller" `
                 -Name "OnlyUseAXISForActiveXInstall" `
-                | Select-Object -ExpandProperty "OnlyUseAXISForActiveXInstall"
+            | Select-Object -ExpandProperty "OnlyUseAXISForActiveXInstall"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-253"
+    Id   = "Registry-253"
     Task = "Set 'Security Zones: Do not allow users to add/delete sites' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "Security_zones_map_edit" `
-                | Select-Object -ExpandProperty "Security_zones_map_edit"
+            | Select-Object -ExpandProperty "Security_zones_map_edit"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-254"
+    Id   = "Registry-254"
     Task = "Set 'Security Zones: Do not allow users to change policies' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "Security_options_edit" `
-                | Select-Object -ExpandProperty "Security_options_edit"
+            | Select-Object -ExpandProperty "Security_options_edit"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-255"
+    Id   = "Registry-255"
     Task = "Set 'Security Zones: Use only machine settings' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "Security_HKLM_only" `
-                | Select-Object -ExpandProperty "Security_HKLM_only"
+            | Select-Object -ExpandProperty "Security_HKLM_only"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-256"
+    Id   = "Registry-256"
     Task = "Ensure 'Check for server certificate revocation' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "CertificateRevocation" `
-                | Select-Object -ExpandProperty "CertificateRevocation"
+            | Select-Object -ExpandProperty "CertificateRevocation"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-257"
+    Id   = "Registry-257"
     Task = "Ensure 'Prevent ignoring certificate errors' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "PreventIgnoreCertErrors" `
-                | Select-Object -ExpandProperty "PreventIgnoreCertErrors"
+            | Select-Object -ExpandProperty "PreventIgnoreCertErrors"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-258"
+    Id   = "Registry-258"
     Task = "Set 'Turn on certificate address mismatch warning' to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "WarnOnBadCertRecving" `
-                | Select-Object -ExpandProperty "WarnOnBadCertRecving"
+            | Select-Object -ExpandProperty "WarnOnBadCertRecving"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-259"
+    Id   = "Registry-259"
     Task = "Ensure 'Allow fallback to SSL 3.0 (Internet Explorer)' is set to 'No Sites'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "EnableSSL3Fallback" `
-                | Select-Object -ExpandProperty "EnableSSL3Fallback"
+            | Select-Object -ExpandProperty "EnableSSL3Fallback"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-260"
+    Id   = "Registry-260"
     Task = "Ensure 'Turn off encryption support' is set to 'Use TLS 1.1 and TLS 1.2'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings" `
                 -Name "SecureProtocols" `
-                | Select-Object -ExpandProperty "SecureProtocols"
+            | Select-Object -ExpandProperty "SecureProtocols"
         
             if (($regValue -ne 2560)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 2560"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-261"
+    Id   = "Registry-261"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'. (Lockdown_Zones/0)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Lockdown_Zones\0" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-262"
+    Id   = "Registry-262"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'. (Lockdown_Zones/1)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Lockdown_Zones\1" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-263"
+    Id   = "Registry-263"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'. (Lockdown_Zones/2)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Lockdown_Zones\2" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-264"
+    Id   = "Registry-264"
     Task = "Ensure 'Turn on SmartScreen Filter scan' is set to 'Enable'. (Lockdown_Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Lockdown_Zones\3" `
                 -Name "2301" `
-                | Select-Object -ExpandProperty "2301"
+            | Select-Object -ExpandProperty "2301"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-265"
+    Id   = "Registry-265"
     Task = "Ensure 'Turn on SmartScreen Filter scan' is set to 'Enable'. (Lockdown_Zones/4)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Lockdown_Zones\4" `
                 -Name "2301" `
-                | Select-Object -ExpandProperty "2301"
+            | Select-Object -ExpandProperty "2301"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-266"
+    Id   = "Registry-266"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'. (Lockdown_Zones/4)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Lockdown_Zones\4" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-267"
+    Id   = "Registry-267"
     Task = "Ensure 'Intranet Sites: Include all network paths (UNCs)' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap" `
                 -Name "UNCAsIntranet" `
-                | Select-Object -ExpandProperty "UNCAsIntranet"
+            | Select-Object -ExpandProperty "UNCAsIntranet"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-268"
+    Id   = "Registry-268"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'. (Zones/0)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-269"
+    Id   = "Registry-269"
     Task = "Ensure 'Don't run antimalware programs against ActiveX controls' is set to 'Disable'. (Zones/0)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0" `
                 -Name "270C" `
-                | Select-Object -ExpandProperty "270C"
+            | Select-Object -ExpandProperty "270C"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-270"
+    Id   = "Registry-270"
     Task = "Ensure 'Don't run antimalware programs against ActiveX controls' is set to 'Disable'. (Zones/1)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1" `
                 -Name "270C" `
-                | Select-Object -ExpandProperty "270C"
+            | Select-Object -ExpandProperty "270C"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-271"
+    Id   = "Registry-271"
     Task = "Ensure 'Initialize and script ActiveX controls not marked as safe' is set to 'Disable'. (Zones/1)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1" `
                 -Name "1201" `
-                | Select-Object -ExpandProperty "1201"
+            | Select-Object -ExpandProperty "1201"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-272"
+    Id   = "Registry-272"
     Task = "Ensure 'Java permissions' is set to 'High safety'. (Zones/1)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if (($regValue -ne 65536)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 65536"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-273"
+    Id   = "Registry-273"
     Task = "Ensure 'Java permissions' is set to 'High safety'. (Zones/2)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if (($regValue -ne 65536)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 65536"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-274"
+    Id   = "Registry-274"
     Task = "Ensure 'Don't run antimalware programs against ActiveX controls' is set to 'Disable'. (Zones/2)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2" `
                 -Name "270C" `
-                | Select-Object -ExpandProperty "270C"
+            | Select-Object -ExpandProperty "270C"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-275"
+    Id   = "Registry-275"
     Task = "Ensure 'Initialize and script ActiveX controls not marked as safe' is set to 'Disable'. (Zones/2)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2" `
                 -Name "1201" `
-                | Select-Object -ExpandProperty "1201"
+            | Select-Object -ExpandProperty "1201"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-276"
+    Id   = "Registry-276"
     Task = "Ensure 'Run .NET Framework-reliant components signed with Authenticode' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2001" `
-                | Select-Object -ExpandProperty "2001"
+            | Select-Object -ExpandProperty "2001"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-277"
+    Id   = "Registry-277"
     Task = "Ensure 'Allow script-initiated windows without size or position constraints' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2102" `
-                | Select-Object -ExpandProperty "2102"
+            | Select-Object -ExpandProperty "2102"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-278"
+    Id   = "Registry-278"
     Task = "Ensure 'Allow drag and drop or copy and paste files' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1802" `
-                | Select-Object -ExpandProperty "1802"
+            | Select-Object -ExpandProperty "1802"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-279"
+    Id   = "Registry-279"
     Task = "Ensure 'Include local path when user is uploading files to a server' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "160A" `
-                | Select-Object -ExpandProperty "160A"
+            | Select-Object -ExpandProperty "160A"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-280"
+    Id   = "Registry-280"
     Task = "Ensure 'Initialize and script ActiveX controls not marked as safe' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1201" `
-                | Select-Object -ExpandProperty "1201"
+            | Select-Object -ExpandProperty "1201"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-281"
+    Id   = "Registry-281"
     Task = "Ensure 'Access data sources across domains' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1406" `
-                | Select-Object -ExpandProperty "1406"
+            | Select-Object -ExpandProperty "1406"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-282"
+    Id   = "Registry-282"
     Task = "Ensure 'Launching applications and files in an IFRAME' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1804" `
-                | Select-Object -ExpandProperty "1804"
+            | Select-Object -ExpandProperty "1804"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-283"
+    Id   = "Registry-283"
     Task = "Ensure 'Automatic prompting for file downloads' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2200" `
-                | Select-Object -ExpandProperty "2200"
+            | Select-Object -ExpandProperty "2200"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-284"
+    Id   = "Registry-284"
     Task = "Ensure 'Allow scriptlets' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1209" `
-                | Select-Object -ExpandProperty "1209"
+            | Select-Object -ExpandProperty "1209"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-285"
+    Id   = "Registry-285"
     Task = "Ensure 'Allow scripting of Internet Explorer WebBrowser controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1206" `
-                | Select-Object -ExpandProperty "1206"
+            | Select-Object -ExpandProperty "1206"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-286"
+    Id   = "Registry-286"
     Task = "Ensure 'Use Pop-up Blocker' is set to 'Enable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1809" `
-                | Select-Object -ExpandProperty "1809"
+            | Select-Object -ExpandProperty "1809"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-287"
+    Id   = "Registry-287"
     Task = "Ensure 'Turn on Protected Mode' is set to 'Enable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2500" `
-                | Select-Object -ExpandProperty "2500"
+            | Select-Object -ExpandProperty "2500"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-288"
+    Id   = "Registry-288"
     Task = "Ensure 'Allow updates to status bar via script' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2103" `
-                | Select-Object -ExpandProperty "2103"
+            | Select-Object -ExpandProperty "2103"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-289"
+    Id   = "Registry-289"
     Task = "Ensure 'Userdata persistence' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1606" `
-                | Select-Object -ExpandProperty "1606"
+            | Select-Object -ExpandProperty "1606"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-290"
+    Id   = "Registry-290"
     Task = "Ensure 'Allow loading of XAML files' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2402" `
-                | Select-Object -ExpandProperty "2402"
+            | Select-Object -ExpandProperty "2402"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-291"
+    Id   = "Registry-291"
     Task = "Ensure 'Run .NET Framework-reliant components not signed with Authenticode' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2004" `
-                | Select-Object -ExpandProperty "2004"
+            | Select-Object -ExpandProperty "2004"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-292"
+    Id   = "Registry-292"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-293"
+    Id   = "Registry-293"
     Task = "Ensure 'Download signed ActiveX controls' is set to 'Disable'. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1001" `
-                | Select-Object -ExpandProperty "1001"
+            | Select-Object -ExpandProperty "1001"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-294"
+    Id   = "Registry-294"
     Task = "Ensure 'Logon options' is set to 'Prompt for user name and password'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1A00" `
-                | Select-Object -ExpandProperty "1A00"
+            | Select-Object -ExpandProperty "1A00"
         
             if (($regValue -ne 65536)) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 65536"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-295"
+    Id   = "Registry-295"
     Task = "Ensure 'Enable dragging of content from different domains within a window' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2708" `
-                | Select-Object -ExpandProperty "2708"
+            | Select-Object -ExpandProperty "2708"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-296"
+    Id   = "Registry-296"
     Task = "Ensure 'Download unsigned ActiveX controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1004" `
-                | Select-Object -ExpandProperty "1004"
+            | Select-Object -ExpandProperty "1004"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-297"
+    Id   = "Registry-297"
     Task = "Ensure 'Allow only approved domains to use ActiveX controls without prompt' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "120b" `
-                | Select-Object -ExpandProperty "120b"
+            | Select-Object -ExpandProperty "120b"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-298"
+    Id   = "Registry-298"
     Task = "Ensure 'Allow cut, copy or paste operations from the clipboard via script' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1407" `
-                | Select-Object -ExpandProperty "1407"
+            | Select-Object -ExpandProperty "1407"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-299"
+    Id   = "Registry-299"
     Task = "Ensure 'Turn on Cross-Site Scripting Filter' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1409" `
-                | Select-Object -ExpandProperty "1409"
+            | Select-Object -ExpandProperty "1409"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-300"
+    Id   = "Registry-300"
     Task = "Ensure 'Don't run antimalware programs against ActiveX controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "270C" `
-                | Select-Object -ExpandProperty "270C"
+            | Select-Object -ExpandProperty "270C"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-301"
+    Id   = "Registry-301"
     Task = "Ensure 'Navigate windows and frames across different domains' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1607" `
-                | Select-Object -ExpandProperty "1607"
+            | Select-Object -ExpandProperty "1607"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-302"
+    Id   = "Registry-302"
     Task = "Ensure 'Enable dragging of content from different domains across windows' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2709" `
-                | Select-Object -ExpandProperty "2709"
+            | Select-Object -ExpandProperty "2709"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-303"
+    Id   = "Registry-303"
     Task = "Ensure 'Web sites in less privileged Web content zones can navigate into this zone' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2101" `
-                | Select-Object -ExpandProperty "2101"
+            | Select-Object -ExpandProperty "2101"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-304"
+    Id   = "Registry-304"
     Task = "Ensure 'Turn on SmartScreen Filter scan' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "2301" `
-                | Select-Object -ExpandProperty "2301"
+            | Select-Object -ExpandProperty "2301"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-305"
+    Id   = "Registry-305"
     Task = "Ensure 'Show security warning for potentially unsafe files' is set to 'Prompt'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "1806" `
-                | Select-Object -ExpandProperty "1806"
+            | Select-Object -ExpandProperty "1806"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-306"
+    Id   = "Registry-306"
     Task = "Ensure 'Allow only approved domains to use the TDC ActiveX control' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "120c" `
-                | Select-Object -ExpandProperty "120c"
+            | Select-Object -ExpandProperty "120c"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-307"
+    Id   = "Registry-307"
     Task = "Set registry value '140C' to 3. (Zones/3)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" `
                 -Name "140C" `
-                | Select-Object -ExpandProperty "140C"
+            | Select-Object -ExpandProperty "140C"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-308"
+    Id   = "Registry-308"
     Task = "Ensure 'Allow META REFRESH' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1608" `
-                | Select-Object -ExpandProperty "1608"
+            | Select-Object -ExpandProperty "1608"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-309"
+    Id   = "Registry-309"
     Task = "Ensure 'Initialize and script ActiveX controls not marked as safe' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1201" `
-                | Select-Object -ExpandProperty "1201"
+            | Select-Object -ExpandProperty "1201"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-310"
+    Id   = "Registry-310"
     Task = "Ensure 'Download signed ActiveX controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1001" `
-                | Select-Object -ExpandProperty "1001"
+            | Select-Object -ExpandProperty "1001"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-311"
+    Id   = "Registry-311"
     Task = "Ensure 'Navigate windows and frames across different domains' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1607" `
-                | Select-Object -ExpandProperty "1607"
+            | Select-Object -ExpandProperty "1607"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-312"
+    Id   = "Registry-312"
     Task = "Ensure 'Allow only approved domains to use ActiveX controls without prompt' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "120b" `
-                | Select-Object -ExpandProperty "120b"
+            | Select-Object -ExpandProperty "120b"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-313"
+    Id   = "Registry-313"
     Task = "Ensure 'Use Pop-up Blocker' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1809" `
-                | Select-Object -ExpandProperty "1809"
+            | Select-Object -ExpandProperty "1809"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-314"
+    Id   = "Registry-314"
     Task = "Ensure 'Download unsigned ActiveX controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1004" `
-                | Select-Object -ExpandProperty "1004"
+            | Select-Object -ExpandProperty "1004"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-315"
+    Id   = "Registry-315"
     Task = "Ensure 'Userdata persistence' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1606" `
-                | Select-Object -ExpandProperty "1606"
+            | Select-Object -ExpandProperty "1606"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-316"
+    Id   = "Registry-316"
     Task = "Ensure 'Allow cut, copy or paste operations from the clipboard via script' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1407" `
-                | Select-Object -ExpandProperty "1407"
+            | Select-Object -ExpandProperty "1407"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-317"
+    Id   = "Registry-317"
     Task = "Ensure 'Include local path when user is uploading files to a server' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "160A" `
-                | Select-Object -ExpandProperty "160A"
+            | Select-Object -ExpandProperty "160A"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-318"
+    Id   = "Registry-318"
     Task = "Ensure 'Access data sources across domains' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1406" `
-                | Select-Object -ExpandProperty "1406"
+            | Select-Object -ExpandProperty "1406"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-319"
+    Id   = "Registry-319"
     Task = "Ensure 'Allow script-initiated windows without size or position constraints' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2102" `
-                | Select-Object -ExpandProperty "2102"
+            | Select-Object -ExpandProperty "2102"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-320"
+    Id   = "Registry-320"
     Task = "Ensure 'Run .NET Framework-reliant components not signed with Authenticode' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2004" `
-                | Select-Object -ExpandProperty "2004"
+            | Select-Object -ExpandProperty "2004"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-321"
+    Id   = "Registry-321"
     Task = "Ensure 'Automatic prompting for file downloads' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2200" `
-                | Select-Object -ExpandProperty "2200"
+            | Select-Object -ExpandProperty "2200"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-322"
+    Id   = "Registry-322"
     Task = "Ensure 'Allow binary and script behaviors' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2000" `
-                | Select-Object -ExpandProperty "2000"
+            | Select-Object -ExpandProperty "2000"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-323"
+    Id   = "Registry-323"
     Task = "Ensure 'Scripting of Java applets' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1402" `
-                | Select-Object -ExpandProperty "1402"
+            | Select-Object -ExpandProperty "1402"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-324"
+    Id   = "Registry-324"
     Task = "Ensure 'Allow file downloads' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1803" `
-                | Select-Object -ExpandProperty "1803"
+            | Select-Object -ExpandProperty "1803"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-325"
+    Id   = "Registry-325"
     Task = "Ensure 'Allow loading of XAML files' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2402" `
-                | Select-Object -ExpandProperty "2402"
+            | Select-Object -ExpandProperty "2402"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-326"
+    Id   = "Registry-326"
     Task = "Ensure 'Allow active scripting' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1400" `
-                | Select-Object -ExpandProperty "1400"
+            | Select-Object -ExpandProperty "1400"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-327"
+    Id   = "Registry-327"
     Task = "Ensure 'Logon options' is set to 'Anonymous logon'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1A00" `
-                | Select-Object -ExpandProperty "1A00"
+            | Select-Object -ExpandProperty "1A00"
         
             if ($regValue -ne 196608) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: x == 196608"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-328"
+    Id   = "Registry-328"
     Task = "Ensure 'Run .NET Framework-reliant components signed with Authenticode' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2001" `
-                | Select-Object -ExpandProperty "2001"
+            | Select-Object -ExpandProperty "2001"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-329"
+    Id   = "Registry-329"
     Task = "Ensure 'Turn on Protected Mode' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2500" `
-                | Select-Object -ExpandProperty "2500"
+            | Select-Object -ExpandProperty "2500"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-330"
+    Id   = "Registry-330"
     Task = "Ensure 'Turn on Cross-Site Scripting Filter' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1409" `
-                | Select-Object -ExpandProperty "1409"
+            | Select-Object -ExpandProperty "1409"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-331"
+    Id   = "Registry-331"
     Task = "Ensure 'Java permissions' is set to 'Disable Java'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1C00" `
-                | Select-Object -ExpandProperty "1C00"
+            | Select-Object -ExpandProperty "1C00"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-332"
+    Id   = "Registry-332"
     Task = "Ensure 'Allow scriptlets' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1209" `
-                | Select-Object -ExpandProperty "1209"
+            | Select-Object -ExpandProperty "1209"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-333"
+    Id   = "Registry-333"
     Task = "Ensure 'Don't run antimalware programs against ActiveX controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "270C" `
-                | Select-Object -ExpandProperty "270C"
+            | Select-Object -ExpandProperty "270C"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-334"
+    Id   = "Registry-334"
     Task = "Ensure 'Allow scripting of Internet Explorer WebBrowser controls' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1206" `
-                | Select-Object -ExpandProperty "1206"
+            | Select-Object -ExpandProperty "1206"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-335"
+    Id   = "Registry-335"
     Task = "Ensure 'Enable dragging of content from different domains within a window' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2708" `
-                | Select-Object -ExpandProperty "2708"
+            | Select-Object -ExpandProperty "2708"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-336"
+    Id   = "Registry-336"
     Task = "Ensure 'Allow drag and drop or copy and paste files' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1802" `
-                | Select-Object -ExpandProperty "1802"
+            | Select-Object -ExpandProperty "1802"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-337"
+    Id   = "Registry-337"
     Task = "Ensure 'Allow updates to status bar via script' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2103" `
-                | Select-Object -ExpandProperty "2103"
+            | Select-Object -ExpandProperty "2103"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-338"
+    Id   = "Registry-338"
     Task = "Ensure 'Enable dragging of content from different domains across windows' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2709" `
-                | Select-Object -ExpandProperty "2709"
+            | Select-Object -ExpandProperty "2709"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-339"
+    Id   = "Registry-339"
     Task = "Ensure 'Script ActiveX controls marked safe for scripting' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1405" `
-                | Select-Object -ExpandProperty "1405"
+            | Select-Object -ExpandProperty "1405"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-340"
+    Id   = "Registry-340"
     Task = "Ensure 'Web sites in less privileged Web content zones can navigate into this zone' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2101" `
-                | Select-Object -ExpandProperty "2101"
+            | Select-Object -ExpandProperty "2101"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-341"
+    Id   = "Registry-341"
     Task = "Ensure 'Turn on SmartScreen Filter scan' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "2301" `
-                | Select-Object -ExpandProperty "2301"
+            | Select-Object -ExpandProperty "2301"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-342"
+    Id   = "Registry-342"
     Task = "Ensure 'Run ActiveX controls and plugins' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1200" `
-                | Select-Object -ExpandProperty "1200"
+            | Select-Object -ExpandProperty "1200"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-343"
+    Id   = "Registry-343"
     Task = "Ensure 'Launching applications and files in an IFRAME' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1804" `
-                | Select-Object -ExpandProperty "1804"
+            | Select-Object -ExpandProperty "1804"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-344"
+    Id   = "Registry-344"
     Task = "Ensure 'Show security warning for potentially unsafe files' is set to 'Disable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "1806" `
-                | Select-Object -ExpandProperty "1806"
+            | Select-Object -ExpandProperty "1806"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-345"
+    Id   = "Registry-345"
     Task = "Ensure 'Allow only approved domains to use the TDC ActiveX control' is set to 'Enable'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "120c" `
-                | Select-Object -ExpandProperty "120c"
+            | Select-Object -ExpandProperty "120c"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-346"
+    Id   = "Registry-346"
     Task = "Set registry value '140C' to 3. (Zones/4)"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\4" `
                 -Name "140C" `
-                | Select-Object -ExpandProperty "140C"
+            | Select-Object -ExpandProperty "140C"
         
             if ($regValue -ne 3) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 3"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-347"
+    Id   = "Registry-347"
     Task = "Set 'Turn on the auto-complete feature for user names and passwords on forms' to 'Disabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Internet Explorer\Control Panel" `
                 -Name "FormSuggest Passwords" `
-                | Select-Object -ExpandProperty "FormSuggest Passwords"
+            | Select-Object -ExpandProperty "FormSuggest Passwords"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-348"
+    Id   = "Registry-348"
     Task = "Ensure 'Turn on the auto-complete feature for user names and passwords on forms' is set to 'no'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Internet Explorer\Main" `
                 -Name "FormSuggest PW Ask" `
-                | Select-Object -ExpandProperty "FormSuggest PW Ask"
+            | Select-Object -ExpandProperty "FormSuggest PW Ask"
         
             if ($regValue -ne "no") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: no"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-349"
+    Id   = "Registry-349"
     Task = "Set registry value 'FormSuggest Passwords' to no."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Internet Explorer\Main" `
                 -Name "FormSuggest Passwords" `
-                | Select-Object -ExpandProperty "FormSuggest Passwords"
+            | Select-Object -ExpandProperty "FormSuggest Passwords"
         
             if ($regValue -ne "no") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: no"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-351"
+    Id   = "Registry-351"
     Task = "Ensure 'Allow enhanced PINs for startup' is set 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "UseEnhancedPin" `
-                | Select-Object -ExpandProperty "UseEnhancedPin"
+            | Select-Object -ExpandProperty "UseEnhancedPin"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-352"
+    Id   = "Registry-352"
     Task = "Set registry value 'RDVDenyCrossOrg' to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "RDVDenyCrossOrg" `
-                | Select-Object -ExpandProperty "RDVDenyCrossOrg"
+            | Select-Object -ExpandProperty "RDVDenyCrossOrg"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-353"
+    Id   = "Registry-353"
     Task = "Ensure 'Disable new DMA devices when this computer is locked' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\FVE" `
                 -Name "DisableExternalDMAUnderLock" `
-                | Select-Object -ExpandProperty "DisableExternalDMAUnderLock"
+            | Select-Object -ExpandProperty "DisableExternalDMAUnderLock"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-354"
+    Id   = "Registry-354"
     Task = "Ensure 'Allow Standby States (S1-S3) When Sleeping (On Battery)' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\abfc2519-3608-4c2a-94ea-171b0ed546ab" `
                 -Name "DCSettingIndex" `
-                | Select-Object -ExpandProperty "DCSettingIndex"
+            | Select-Object -ExpandProperty "DCSettingIndex"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-355"
+    Id   = "Registry-355"
     Task = "Ensure 'Allow Standby States (S1-S3) When Sleeping (Plugged In)' is set to 'Disabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Power\PowerSettings\abfc2519-3608-4c2a-94ea-171b0ed546ab" `
                 -Name "ACSettingIndex" `
-                | Select-Object -ExpandProperty "ACSettingIndex"
+            | Select-Object -ExpandProperty "ACSettingIndex"
         
             if ($regValue -ne 0) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 0"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-356"
+    Id   = "Registry-356"
     Task = "Ensure 'Prevent installation of devices using drivers that match these device setup classes' set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions" `
                 -Name "DenyDeviceClasses" `
-                | Select-Object -ExpandProperty "DenyDeviceClasses"
+            | Select-Object -ExpandProperty "DenyDeviceClasses"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-357"
+    Id   = "Registry-357"
     Task = "Ensure 'Prevent installation of devices using drivers that match these device setup classes' set to 'Also apply to matching devices that are already installed. (True) '."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions" `
                 -Name "DenyDeviceClassesRetroactive" `
-                | Select-Object -ExpandProperty "DenyDeviceClassesRetroactive"
+            | Select-Object -ExpandProperty "DenyDeviceClassesRetroactive"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-358"
+    Id   = "Registry-358"
     Task = "Ensure 'Prevent installation of devices using drivers that match these device setup classes: Prevent installation of devices using drivers for these device setup' is set to 'IEEE 1394 device setup classes' [IEEE 1394 devices that support the SBP2 Protocol Class]"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\DeviceInstall\Restrictions\DenyDeviceClasses" `
                 -Name "1" `
-                | Select-Object -ExpandProperty "1"
+            | Select-Object -ExpandProperty "1"
         
             if ($regValue -ne "{d48179be-ec20-11d1-b6b8-00c04fa372a7}") {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: {d48179be-ec20-11d1-b6b8-00c04fa372a7}"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-359"
+    Id   = "Registry-359"
     Task = "Ensure 'Deny write access to removable drives not protected by BitLocker' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Policies\Microsoft\FVE" `
                 -Name "RDVDenyWriteAccess" `
-                | Select-Object -ExpandProperty "RDVDenyWriteAccess"
+            | Select-Object -ExpandProperty "RDVDenyWriteAccess"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-368"
+    Id   = "Registry-368"
     Task = "Ensure 'Turn On Virtualization Based Security' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "EnableVirtualizationBasedSecurity" `
-                | Select-Object -ExpandProperty "EnableVirtualizationBasedSecurity"
+            | Select-Object -ExpandProperty "EnableVirtualizationBasedSecurity"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-369"
+    Id   = "Registry-369"
     Task = "Ensure 'Turn On Virtualization Based Security' is set to 'Secure Boot'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "RequirePlatformSecurityFeatures" `
-                | Select-Object -ExpandProperty "RequirePlatformSecurityFeatures"
+            | Select-Object -ExpandProperty "RequirePlatformSecurityFeatures"
         
             if ($regValue -eq 3) {
                 return @{
                     Message = "Set to 'Secure Boot and DMA Protection' which is more secure."
-                    Status = "True"
+                    Status  = "True"
                 }
             }
                 
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-370"
+    Id   = "Registry-370"
     Task = "Ensure 'Turn On Virtualization Based Security' is set to 'Enabled with UEFI lock'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "HypervisorEnforcedCodeIntegrity" `
-                | Select-Object -ExpandProperty "HypervisorEnforcedCodeIntegrity"
+            | Select-Object -ExpandProperty "HypervisorEnforcedCodeIntegrity"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-371"
+    Id   = "Registry-371"
     Task = "Ensure 'Turn On Virtualization Based Security: Require UEFI Memory Attributes Table' is set to 'True (checked)'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "HVCIMATRequired" `
-                | Select-Object -ExpandProperty "HVCIMATRequired"
+            | Select-Object -ExpandProperty "HVCIMATRequired"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-372"
+    Id   = "Registry-372"
     Task = "Ensure 'Turn On Virtualization Based Security' is set to 'Enabled with UEFI lock'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "LsaCfgFlags" `
-                | Select-Object -ExpandProperty "LsaCfgFlags"
+            | Select-Object -ExpandProperty "LsaCfgFlags"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-373"
+    Id   = "Registry-373"
     Task = "Ensure 'Turn On Virtualization Based Security: Secure Launch Configuration' is set to 'Enabled'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "ConfigureSystemGuardLaunch" `
-                | Select-Object -ExpandProperty "ConfigureSystemGuardLaunch"
+            | Select-Object -ExpandProperty "ConfigureSystemGuardLaunch"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-374"
+    Id   = "Registry-374"
     Task = "Ensure 'Turn On Virtualization Based Security: Kernel-mode Hardware-enforced Stack Protection' is set to 'Enabled: Enabled in enforcement mode'"
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\DeviceGuard" `
                 -Name "ConfigureKernelShadowStacksLaunch" `
-                | Select-Object -ExpandProperty "ConfigureKernelShadowStacksLaunch"
+            | Select-Object -ExpandProperty "ConfigureKernelShadowStacksLaunch"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-375"
+    Id   = "Registry-375"
     Task = "Ensure 'Do not suggest third-party content in Windows spotlight' is set to 'Enabled'."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\CloudContent" `
                 -Name "DisableThirdPartySuggestions" `
-                | Select-Object -ExpandProperty "DisableThirdPartySuggestions"
+            | Select-Object -ExpandProperty "DisableThirdPartySuggestions"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }
 [AuditTest] @{
-    Id = "Registry-376"
+    Id   = "Registry-376"
     Task = "Toast notifications to the lock screen must be turned off."
     Test = {
         try {
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\PushNotifications" `
                 -Name "NoToastApplicationNotificationOnLockScreen" `
-                | Select-Object -ExpandProperty "NoToastApplicationNotificationOnLockScreen"
+            | Select-Object -ExpandProperty "NoToastApplicationNotificationOnLockScreen"
         
             if ($regValue -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
-                    Status = "False"
+                    Status  = "False"
                 }
             }
         }
         catch [System.Management.Automation.PSArgumentException] {
             return @{
                 Message = "Registry value not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         catch [System.Management.Automation.ItemNotFoundException] {
             return @{
                 Message = "Registry key not found."
-                Status = "False"
+                Status  = "False"
             }
         }
         
         return @{
             Message = "Compliant"
-            Status = "True"
+            Status  = "True"
         }
     }
 }

--- a/ATAPAuditor/AuditGroups/Microsoft Windows 11-Microsoft-22H2#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows 11-Microsoft-22H2#RegistrySettings.ps1
@@ -5507,14 +5507,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR"
+            $Value = "ExploitGuard_ASR_Rules"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR" `
-                -Name "ExploitGuard_ASR_Rules" `
-            | Select-Object -ExpandProperty "ExploitGuard_ASR_Rules"
-        
-            if ($regValue -ne 1) {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR"
+            $Value2 = "ExploitGuard_ASR_Rules"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5533,7 +5551,7 @@ $windefrunning = CheckWindefRunning
                 Status  = "False"
             }
         }
-        
+
         return @{
             Message = "Compliant"
             Status  = "True"
@@ -5553,14 +5571,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84" `
-            | Select-Object -ExpandProperty "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "75668c1f-73b5-4cf0-bb93-3ecf5cb7cc84"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5599,14 +5635,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "3b576869-a4ec-4529-8536-b80a7769e899"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "3b576869-a4ec-4529-8536-b80a7769e899" `
-            | Select-Object -ExpandProperty "3b576869-a4ec-4529-8536-b80a7769e899"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "3b576869-a4ec-4529-8536-b80a7769e899"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5645,14 +5699,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "d4f940ab-401b-4efc-aadc-ad5f3c50688a" `
-            | Select-Object -ExpandProperty "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5691,14 +5763,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B" `
-            | Select-Object -ExpandProperty "92E97FA1-2EDF-4476-BDD6-9DD0B4DDDC7B"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5737,14 +5827,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "5beb7efe-fd9a-4556-801d-275e5ffc04cc" 
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "5beb7efe-fd9a-4556-801d-275e5ffc04cc" `
-            | Select-Object -ExpandProperty "5beb7efe-fd9a-4556-801d-275e5ffc04cc"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "5beb7efe-fd9a-4556-801d-275e5ffc04cc" 
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5783,14 +5891,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "d3e037e1-3eb8-44c8-a917-57927947596d"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "d3e037e1-3eb8-44c8-a917-57927947596d" `
-            | Select-Object -ExpandProperty "d3e037e1-3eb8-44c8-a917-57927947596d"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "d3e037e1-3eb8-44c8-a917-57927947596d"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5829,14 +5955,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550" `
-            | Select-Object -ExpandProperty "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "be9ba2d9-53ea-4cdc-84e5-9b1eeee46550"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5875,14 +6019,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2" `
-            | Select-Object -ExpandProperty "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "9e6c4e1f-7d60-472f-ba1a-a39ef669e4b2"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5921,14 +6083,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4" `
-            | Select-Object -ExpandProperty "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "b2b3f03d-6a65-4f7b-a9c7-1c7ef74a9ba4"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -5967,14 +6147,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "26190899-1602-49e8-8b27-eb1d0a1ce869"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "26190899-1602-49e8-8b27-eb1d0a1ce869" `
-            | Select-Object -ExpandProperty "26190899-1602-49e8-8b27-eb1d0a1ce869"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "26190899-1602-49e8-8b27-eb1d0a1ce869"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -6013,14 +6211,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c" `
-            | Select-Object -ExpandProperty "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "7674ba52-37eb-4a4f-a9a1-f0f9a1619a2c"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -6105,14 +6321,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "e6db77e5-3df2-4cf1-b95a-636979351e5b"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "e6db77e5-3df2-4cf1-b95a-636979351e5b" `
-            | Select-Object -ExpandProperty "e6db77e5-3df2-4cf1-b95a-636979351e5b"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "e6db77e5-3df2-4cf1-b95a-636979351e5b"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -6131,7 +6365,7 @@ $windefrunning = CheckWindefRunning
                 Status  = "False"
             }
         }
-        
+
         return @{
             Message = "Compliant"
             Status  = "True"
@@ -6151,14 +6385,32 @@ $windefrunning = CheckWindefRunning
                         Status  = "None"
                     }
                 }
+            }                  
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "56a863a9-875e-4185-98a7-b882c64b5ce5"
+
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
             }
 
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "56a863a9-875e-4185-98a7-b882c64b5ce5" `
-            | Select-Object -ExpandProperty "56a863a9-875e-4185-98a7-b882c64b5ce5"
-        
-            if ($regValue -ne "1") {
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "56a863a9-875e-4185-98a7-b882c64b5ce5"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -6177,7 +6429,7 @@ $windefrunning = CheckWindefRunning
                 Status  = "False"
             }
         }
-        
+
         return @{
             Message = "Compliant"
             Status  = "True"

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2025-CIS-1.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2025-CIS-1.0.0#RegistrySettings.ps1
@@ -1,7 +1,6 @@
 ﻿$RootPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 $RootPath = Split-Path $RootPath -Parent
 . "$RootPath\Helpers\AuditGroupFunctions.ps1"
-$avstatus = CheckForActiveAV
 $windefrunning = CheckWindefRunning
 . "$RootPath\Helpers\Firewall.ps1"
 # 2025

--- a/ATAPAuditor/AuditGroups/Microsoft Windows Server 2025-CIS-1.0.0#RegistrySettings.ps1
+++ b/ATAPAuditor/AuditGroups/Microsoft Windows Server 2025-CIS-1.0.0#RegistrySettings.ps1
@@ -10676,7 +10676,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
  
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -10737,7 +10737,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -10850,8 +10850,8 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
                 return @{
                     Message = "This rule requires Windows Defender Antivirus to be enabled."
                     Status  = "None"
+                }
             }
-        }
             $regValue = 0;
             $regValueTwo = 0;
             $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
@@ -10859,7 +10859,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -10920,7 +10920,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -10981,7 +10981,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -11029,12 +11029,37 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
     Task = "(L1) Ensure 'Configure Attack Surface Reduction rules: Block Office applications from creating child processes'"
     Test = {
         try {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
-                -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules" `
-                -Name "d4f940ab-401b-4efc-aadc-ad5f3c50688a" `
-            | Select-Object -ExpandProperty "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
+            if ((-not $windefrunning)) {
+                return @{
+                    Message = "This rule requires Windows Defender Antivirus to be enabled."
+                    Status  = "None"
+                }
+            }
+            $regValue = 0;
+            $regValueTwo = 0;
+            $Path = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value = "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
 
-            if ($regValue -ne "1") {
+            $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
+            if ($asrTest1) {
+                $regValue = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path `
+                    -Name $Value `
+                | Select-Object -ExpandProperty $Value
+            }
+
+            $Path2 = "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\Windows Defender Exploit Guard\ASR\Rules"
+            $Value2 = "d4f940ab-401b-4efc-aadc-ad5f3c50688a"
+
+            $asrTest2 = Test-ASRRules -Path $Path2 -Value $Value2 
+            if ($asrTest2) {
+                $regValueTwo = Get-ItemProperty -ErrorAction Stop `
+                    -Path $Path2 `
+                    -Name $Value2 `
+                | Select-Object -ExpandProperty $Value2
+            }
+
+            if ($regValue -ne 1 -and $regValueTwo -ne 1) {
                 return @{
                     Message = "Registry value is '$regValue'. Expected: 1"
                     Status  = "False"
@@ -11078,7 +11103,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -11139,7 +11164,7 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
 
             $asrTest1 = Test-ASRRules -Path $Path -Value $Value 
             if ($asrTest1) {
-            $regValue = Get-ItemProperty -ErrorAction Stop `
+                $regValue = Get-ItemProperty -ErrorAction Stop `
                     -Path $Path `
                     -Name $Value `
                 | Select-Object -ExpandProperty $Value
@@ -11233,8 +11258,8 @@ $WINSStatus = (Get-WindowsFeature -Name WINS).Installed
                 return @{
                     Message = "This rule requires Windows Defender Antivirus to be enabled."
                     Status  = "None"
-        }
-    }
+                }
+            }
             $regValue = Get-ItemProperty -ErrorAction Stop `
                 -Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows Defender\NIS" `
                 -Name "EnableConvertWarnToBlock" `


### PR DESCRIPTION
checked all auditgroups regarding logic of ASR rules and changed ASR rules in the following Benchmarks:
- Microsoft Windows 10 BSI HD
- Microsoft Windows 10 CIS Stand-Alone
- Microsoft Windows 11 CIS 4.0.0
- Microsoft Windows 11 22H2 Microsoft
- Microsoft Windows Server 2025 CIS 1.0.0

every ASR rule now calls the Test-ASRRules method and checks avstatus and windefrunning IF it is a client system OR only windefrunning IF it is a server system benchmark