### PR TITLE
Ticket 737

### DIFF
--- a/ATAPAuditor/AuditGroups/SBD - Windows Base Security.ps1
+++ b/ATAPAuditor/AuditGroups/SBD - Windows Base Security.ps1
@@ -1,10 +1,13 @@
 $RootPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 $RootPath = Split-Path $RootPath -Parent
 . "$RootPath\Helpers\AuditGroupFunctions.ps1"
+
 [AuditTest] @{
 	Id   = "SBD-201"
 	Task = "Get License status."
-	Test = {	
+	Test = {
+		$lcStatus = Get-LicenseStatus $SkipLicenseCheck
+		Write-Host "License Status: $lcStatus"
 		if ($lcStatus -eq "Licensed") {
 			return @{
 				Message = "Compliant"


### PR DESCRIPTION
- added a scriptwide cache parameter for license check (performancewise)
- changed function call in SDB script
- changed Get-LicenseStatus to fill the cache paramter